### PR TITLE
Fixed --nohdf5 Configure Flag

### DIFF
--- a/GRHayL/EOS/Tabulated/NRPyEOS_free_memory.c
+++ b/GRHayL/EOS/Tabulated/NRPyEOS_free_memory.c
@@ -3,8 +3,8 @@
  * (c) 2022 Leo Werneck
  */
 void NRPyEOS_free_memory(ghl_eos_parameters *restrict eos) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
 #else
   ghl_info("*******************************\n");
   ghl_info("Freeing up memory.\n");

--- a/GRHayL/EOS/Tabulated/NRPyEOS_initialize_tabulated_functions.c
+++ b/GRHayL/EOS/Tabulated/NRPyEOS_initialize_tabulated_functions.c
@@ -1,8 +1,8 @@
 #include "ghl_nrpyeos_tabulated.h"
 
 void NRPyEOS_initialize_tabulated_functions() {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
 #else
   // clang-format off
   ghl_tabulated_read_table_set_EOS_params              = &NRPyEOS_read_table_set_EOS_params;

--- a/GRHayL/EOS/Tabulated/NRPyEOS_read_table_set_EOS_params.c
+++ b/GRHayL/EOS/Tabulated/NRPyEOS_read_table_set_EOS_params.c
@@ -31,6 +31,7 @@ static inline double get_EOS_table_max(
       const int var_key) {
 #ifndef GRHAYL_USE_HDF5
   HDF5_ERROR_IF_USED;
+  return NAN;
 #else
   // Loop over the table, searching for the maximum value
   const int totalsize  = eos->N_rho * eos->N_Ye * eos->N_T;
@@ -50,6 +51,7 @@ static inline double get_EOS_table_min(
       const int var_key) {
 #ifndef GRHAYL_USE_HDF5
   HDF5_ERROR_IF_USED;
+  return NAN;
 #else
   // Loop over the table, searching for the minimum value
   const int totalsize  = eos->N_rho * eos->N_Ye * eos->N_T;

--- a/GRHayL/EOS/Tabulated/NRPyEOS_read_table_set_EOS_params.c
+++ b/GRHayL/EOS/Tabulated/NRPyEOS_read_table_set_EOS_params.c
@@ -29,8 +29,8 @@
 static inline double get_EOS_table_max(
       const ghl_eos_parameters *restrict eos,
       const int var_key) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return NAN;
 #else
   // Loop over the table, searching for the maximum value
@@ -49,8 +49,8 @@ static inline double get_EOS_table_max(
 static inline double get_EOS_table_min(
       const ghl_eos_parameters *restrict eos,
       const int var_key) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return NAN;
 #else
   // Loop over the table, searching for the minimum value
@@ -69,8 +69,8 @@ static inline double get_EOS_table_min(
  * (c) 2022 Leo Werneck
  */
 void NRPyEOS_read_table_set_EOS_params(const char *EOS_tablename, ghl_eos_parameters *restrict eos_params) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
 #else
   check_if_file_exists(EOS_tablename);
 

--- a/GRHayL/EOS/Tabulated/NRPyEOS_tabulated_compute_Ye_of_rho_beq_constant_T.c
+++ b/GRHayL/EOS/Tabulated/NRPyEOS_tabulated_compute_Ye_of_rho_beq_constant_T.c
@@ -173,7 +173,9 @@ double NRPyEOS_tabulated_compute_eps_from_rho(
 void NRPyEOS_tabulated_compute_Ye_of_rho_beq_constant_T(
       const double T,
       ghl_eos_parameters *restrict eos) {
-
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+#else
   const int it = ghl_tabulated_get_index_T(eos, T);
   const int nr = eos->N_rho;
   const int ny = eos->N_Ye;
@@ -190,12 +192,15 @@ void NRPyEOS_tabulated_compute_Ye_of_rho_beq_constant_T(
     eos->Ye_of_lr[ir] = find_Ye_st_munu_is_zero(ny, eos->table_Y_e, munu_of_Ye);
   }
   free(munu_of_Ye);
+#endif
 }
 
 void NRPyEOS_tabulated_compute_Ye_P_eps_of_rho_beq_constant_T(
       const double T,
       ghl_eos_parameters *restrict eos) {
-
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+#else
   // Start by obtaining Ye(logrho)
   NRPyEOS_tabulated_compute_Ye_of_rho_beq_constant_T(T, eos);
 
@@ -220,6 +225,7 @@ void NRPyEOS_tabulated_compute_Ye_P_eps_of_rho_beq_constant_T(
     eos->le_of_lr[ir] = log(eps + eos->energy_shift);
     eos->lh_of_lr[ir] = log(1.0 + eps + P / rho);
   }
+#endif
 }
 
 void NRPyEOS_tabulated_free_beq_quantities(ghl_eos_parameters *restrict eos) {

--- a/GRHayL/EOS/Tabulated/NRPyEOS_tabulated_compute_Ye_of_rho_beq_constant_T.c
+++ b/GRHayL/EOS/Tabulated/NRPyEOS_tabulated_compute_Ye_of_rho_beq_constant_T.c
@@ -4,6 +4,7 @@
   (NRPyEOS_munu_key            \
    + NRPyEOS_ntablekeys * ((ir) + eos->N_rho * ((it) + eos->N_T * (iy))))
 
+#ifndef GRHAYL_DISABLE_HDF5
 static double find_Ye_st_munu_is_zero(
       const int n,
       const double *restrict Ye,
@@ -30,6 +31,7 @@ static double find_Ye_st_munu_is_zero(
 
   return (y0 * x1 - y1 * x0) / (y0 - y1);
 }
+#endif
 
 static int find_left_index_uniform_array(
       const int nx,

--- a/GRHayL/EOS/Tabulated/NRPyEOS_tabulated_compute_Ye_of_rho_beq_constant_T.c
+++ b/GRHayL/EOS/Tabulated/NRPyEOS_tabulated_compute_Ye_of_rho_beq_constant_T.c
@@ -173,8 +173,8 @@ double NRPyEOS_tabulated_compute_eps_from_rho(
 void NRPyEOS_tabulated_compute_Ye_of_rho_beq_constant_T(
       const double T,
       ghl_eos_parameters *restrict eos) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
 #else
   const int it = ghl_tabulated_get_index_T(eos, T);
   const int nr = eos->N_rho;
@@ -198,8 +198,8 @@ void NRPyEOS_tabulated_compute_Ye_of_rho_beq_constant_T(
 void NRPyEOS_tabulated_compute_Ye_P_eps_of_rho_beq_constant_T(
       const double T,
       ghl_eos_parameters *restrict eos) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
 #else
   // Start by obtaining Ye(logrho)
   NRPyEOS_tabulated_compute_Ye_of_rho_beq_constant_T(T, eos);

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_S_depsdT_and_T_from_rho_Ye_eps.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_S_depsdT_and_T_from_rho_Ye_eps.c
@@ -11,8 +11,8 @@ ghl_error_codes_t NRPyEOS_P_S_depsdT_and_T_from_rho_Ye_eps(
       double *restrict S,
       double *restrict depsdT,
       double *restrict T) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_S_depsdT_and_T_from_rho_Ye_eps.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_S_depsdT_and_T_from_rho_Ye_eps.c
@@ -11,6 +11,10 @@ ghl_error_codes_t NRPyEOS_P_S_depsdT_and_T_from_rho_Ye_eps(
       double *restrict S,
       double *restrict depsdT,
       double *restrict T) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[3] = {NRPyEOS_press_key,NRPyEOS_entropy_key,NRPyEOS_depsdT_key};
@@ -34,4 +38,5 @@ ghl_error_codes_t NRPyEOS_P_S_depsdT_and_T_from_rho_Ye_eps(
   *depsdT = outvars[2];
 
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_and_T_from_rho_Ye_S.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_and_T_from_rho_Ye_S.c
@@ -9,6 +9,10 @@ ghl_error_codes_t NRPyEOS_P_and_T_from_rho_Ye_S(
       const double S,
       double *restrict P,
       double *restrict T) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[1] = {NRPyEOS_press_key};
@@ -29,4 +33,5 @@ ghl_error_codes_t NRPyEOS_P_and_T_from_rho_Ye_S(
   // Step 5: Update output variables
   *P = outvars[0];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_and_T_from_rho_Ye_S.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_and_T_from_rho_Ye_S.c
@@ -9,8 +9,8 @@ ghl_error_codes_t NRPyEOS_P_and_T_from_rho_Ye_S(
       const double S,
       double *restrict P,
       double *restrict T) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_and_T_from_rho_Ye_eps.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_and_T_from_rho_Ye_eps.c
@@ -9,8 +9,8 @@ ghl_error_codes_t NRPyEOS_P_and_T_from_rho_Ye_eps(
       const double eps,
       double *restrict P,
       double *restrict T) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_and_T_from_rho_Ye_eps.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_and_T_from_rho_Ye_eps.c
@@ -9,6 +9,10 @@ ghl_error_codes_t NRPyEOS_P_and_T_from_rho_Ye_eps(
       const double eps,
       double *restrict P,
       double *restrict T) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[1] = {NRPyEOS_press_key};
@@ -29,4 +33,5 @@ ghl_error_codes_t NRPyEOS_P_and_T_from_rho_Ye_eps(
   // Step 5: Update output variables
   *P = outvars[0];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_and_eps_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_and_eps_from_rho_Ye_T.c
@@ -9,6 +9,10 @@ ghl_error_codes_t NRPyEOS_P_and_eps_from_rho_Ye_T(
       const double T,
       double *restrict P,
       double *restrict eps) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[2] = {NRPyEOS_press_key,NRPyEOS_eps_key};
@@ -28,4 +32,5 @@ ghl_error_codes_t NRPyEOS_P_and_eps_from_rho_Ye_T(
   *P = outvars[0];
   *eps = outvars[1];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_and_eps_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_and_eps_from_rho_Ye_T.c
@@ -9,8 +9,8 @@ ghl_error_codes_t NRPyEOS_P_and_eps_from_rho_Ye_T(
       const double T,
       double *restrict P,
       double *restrict eps) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_cs2_and_T_from_rho_Ye_eps.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_cs2_and_T_from_rho_Ye_eps.c
@@ -10,6 +10,10 @@ ghl_error_codes_t NRPyEOS_P_cs2_and_T_from_rho_Ye_eps(
       double *restrict P,
       double *restrict cs2,
       double *restrict T) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[2] = {NRPyEOS_press_key, NRPyEOS_cs2_key};
@@ -31,4 +35,5 @@ ghl_error_codes_t NRPyEOS_P_cs2_and_T_from_rho_Ye_eps(
   *P   = outvars[0];
   *cs2 = outvars[1];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_cs2_and_T_from_rho_Ye_eps.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_cs2_and_T_from_rho_Ye_eps.c
@@ -10,8 +10,8 @@ ghl_error_codes_t NRPyEOS_P_cs2_and_T_from_rho_Ye_eps(
       double *restrict P,
       double *restrict cs2,
       double *restrict T) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_S_and_cs2_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_S_and_cs2_from_rho_Ye_T.c
@@ -11,8 +11,8 @@ ghl_error_codes_t NRPyEOS_P_eps_S_and_cs2_from_rho_Ye_T(
       double *restrict eps,
       double *restrict S,
       double *restrict cs2) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_S_and_cs2_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_S_and_cs2_from_rho_Ye_T.c
@@ -11,6 +11,10 @@ ghl_error_codes_t NRPyEOS_P_eps_S_and_cs2_from_rho_Ye_T(
       double *restrict eps,
       double *restrict S,
       double *restrict cs2) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[4] = {NRPyEOS_press_key,NRPyEOS_eps_key,NRPyEOS_entropy_key,NRPyEOS_cs2_key};
@@ -32,4 +36,5 @@ ghl_error_codes_t NRPyEOS_P_eps_S_and_cs2_from_rho_Ye_T(
   *S = outvars[2];
   *cs2 = outvars[3];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_S_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_S_from_rho_Ye_T.c
@@ -10,6 +10,10 @@ ghl_error_codes_t NRPyEOS_P_eps_and_S_from_rho_Ye_T(
       double *restrict P,
       double *restrict eps,
       double *restrict S) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[3] = {NRPyEOS_press_key,NRPyEOS_eps_key,NRPyEOS_entropy_key};
@@ -30,4 +34,5 @@ ghl_error_codes_t NRPyEOS_P_eps_and_S_from_rho_Ye_T(
   *eps = outvars[1];
   *S = outvars[2];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_S_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_S_from_rho_Ye_T.c
@@ -10,8 +10,8 @@ ghl_error_codes_t NRPyEOS_P_eps_and_S_from_rho_Ye_T(
       double *restrict P,
       double *restrict eps,
       double *restrict S) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_T_from_rho_Ye_S.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_T_from_rho_Ye_S.c
@@ -10,8 +10,8 @@ ghl_error_codes_t NRPyEOS_P_eps_and_T_from_rho_Ye_S(
       double *restrict P,
       double *restrict eps,
       double *restrict T) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_T_from_rho_Ye_S.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_T_from_rho_Ye_S.c
@@ -10,6 +10,10 @@ ghl_error_codes_t NRPyEOS_P_eps_and_T_from_rho_Ye_S(
       double *restrict P,
       double *restrict eps,
       double *restrict T) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[2] = {NRPyEOS_press_key,NRPyEOS_eps_key};
@@ -31,4 +35,5 @@ ghl_error_codes_t NRPyEOS_P_eps_and_T_from_rho_Ye_S(
   *P = outvars[0];
   *eps = outvars[1];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_cs2_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_cs2_from_rho_Ye_T.c
@@ -10,6 +10,10 @@ ghl_error_codes_t NRPyEOS_P_eps_and_cs2_from_rho_Ye_T(
       double *restrict P,
       double *restrict eps,
       double *restrict cs2) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[3] = {NRPyEOS_press_key, NRPyEOS_eps_key, NRPyEOS_cs2_key};
@@ -30,4 +34,5 @@ ghl_error_codes_t NRPyEOS_P_eps_and_cs2_from_rho_Ye_T(
   *eps = outvars[1];
   *cs2 = outvars[2];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_cs2_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_cs2_from_rho_Ye_T.c
@@ -10,8 +10,8 @@ ghl_error_codes_t NRPyEOS_P_eps_and_cs2_from_rho_Ye_T(
       double *restrict P,
       double *restrict eps,
       double *restrict cs2) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_depsdT_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_depsdT_from_rho_Ye_T.c
@@ -10,6 +10,10 @@ ghl_error_codes_t NRPyEOS_P_eps_and_depsdT_from_rho_Ye_T(
       double *restrict P,
       double *restrict eps,
       double *restrict depsdT) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[3] = {NRPyEOS_press_key,NRPyEOS_eps_key,NRPyEOS_depsdT_key};
@@ -30,4 +34,5 @@ ghl_error_codes_t NRPyEOS_P_eps_and_depsdT_from_rho_Ye_T(
   *eps = outvars[1];
   *depsdT = outvars[2];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_depsdT_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_and_depsdT_from_rho_Ye_T.c
@@ -10,8 +10,8 @@ ghl_error_codes_t NRPyEOS_P_eps_and_depsdT_from_rho_Ye_T(
       double *restrict P,
       double *restrict eps,
       double *restrict depsdT) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_muhat_mue_mup_and_mun_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_muhat_mue_mup_and_mun_from_rho_Ye_T.c
@@ -13,6 +13,10 @@ ghl_error_codes_t NRPyEOS_P_eps_muhat_mue_mup_and_mun_from_rho_Ye_T(
       double *restrict mu_e,
       double *restrict mu_p,
       double *restrict mu_n) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[6] = {NRPyEOS_press_key,NRPyEOS_eps_key,NRPyEOS_muhat_key,NRPyEOS_mu_e_key,NRPyEOS_mu_p_key,NRPyEOS_mu_n_key};
@@ -36,4 +40,5 @@ ghl_error_codes_t NRPyEOS_P_eps_muhat_mue_mup_and_mun_from_rho_Ye_T(
   *mu_p = outvars[4];
   *mu_n = outvars[5];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_muhat_mue_mup_and_mun_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_eps_muhat_mue_mup_and_mun_from_rho_Ye_T.c
@@ -13,8 +13,8 @@ ghl_error_codes_t NRPyEOS_P_eps_muhat_mue_mup_and_mun_from_rho_Ye_T(
       double *restrict mu_e,
       double *restrict mu_p,
       double *restrict mu_n) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_from_rho_Ye_T.c
@@ -8,8 +8,8 @@ ghl_error_codes_t NRPyEOS_P_from_rho_Ye_T(
       const double Y_e,
       const double T,
       double *restrict P) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_from_rho_Ye_T.c
@@ -8,6 +8,10 @@ ghl_error_codes_t NRPyEOS_P_from_rho_Ye_T(
       const double Y_e,
       const double T,
       double *restrict P) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[1] = {NRPyEOS_press_key};
@@ -26,4 +30,5 @@ ghl_error_codes_t NRPyEOS_P_from_rho_Ye_T(
   // Step 5: Update output variables
   *P = outvars[0];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_T_from_rho_Ye_eps.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_T_from_rho_Ye_eps.c
@@ -8,8 +8,8 @@ ghl_error_codes_t NRPyEOS_T_from_rho_Ye_eps(
       const double Y_e,
       const double eps,
       double *restrict T) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_T_from_rho_Ye_eps.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_T_from_rho_Ye_eps.c
@@ -8,6 +8,10 @@ ghl_error_codes_t NRPyEOS_T_from_rho_Ye_eps(
       const double Y_e,
       const double eps,
       double *restrict T) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int *keys = NULL;
@@ -26,4 +30,5 @@ ghl_error_codes_t NRPyEOS_T_from_rho_Ye_eps(
     return error;
 
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_cs2_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_cs2_from_rho_Ye_T.c
@@ -8,6 +8,10 @@ ghl_error_codes_t NRPyEOS_cs2_from_rho_Ye_T(
       const double Y_e,
       const double T,
       double *restrict cs2) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[1] = {NRPyEOS_cs2_key};
@@ -26,4 +30,5 @@ ghl_error_codes_t NRPyEOS_cs2_from_rho_Ye_T(
   // Step 5: Update output variables
   *cs2 = outvars[0];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_cs2_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_cs2_from_rho_Ye_T.c
@@ -8,8 +8,8 @@ ghl_error_codes_t NRPyEOS_cs2_from_rho_Ye_T(
       const double Y_e,
       const double T,
       double *restrict cs2) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_S_and_T_from_rho_Ye_P.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_S_and_T_from_rho_Ye_P.c
@@ -10,6 +10,10 @@ ghl_error_codes_t NRPyEOS_eps_S_and_T_from_rho_Ye_P(
       double *restrict eps,
       double *restrict S,
       double *restrict T) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[2] = {NRPyEOS_eps_key,NRPyEOS_entropy_key};
@@ -31,4 +35,5 @@ ghl_error_codes_t NRPyEOS_eps_S_and_T_from_rho_Ye_P(
   *eps = outvars[0];
   *S = outvars[1];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_S_and_T_from_rho_Ye_P.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_S_and_T_from_rho_Ye_P.c
@@ -10,8 +10,8 @@ ghl_error_codes_t NRPyEOS_eps_S_and_T_from_rho_Ye_P(
       double *restrict eps,
       double *restrict S,
       double *restrict T) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_and_T_from_rho_Ye_P.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_and_T_from_rho_Ye_P.c
@@ -9,6 +9,10 @@ ghl_error_codes_t NRPyEOS_eps_and_T_from_rho_Ye_P(
       const double P,
       double *restrict eps,
       double *restrict T) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[1] = {NRPyEOS_eps_key};
@@ -29,4 +33,5 @@ ghl_error_codes_t NRPyEOS_eps_and_T_from_rho_Ye_P(
   // Step 5: Update output variables
   *eps = outvars[0];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_and_T_from_rho_Ye_P.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_and_T_from_rho_Ye_P.c
@@ -9,8 +9,8 @@ ghl_error_codes_t NRPyEOS_eps_and_T_from_rho_Ye_P(
       const double P,
       double *restrict eps,
       double *restrict T) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_cs2_and_T_from_rho_Ye_P.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_cs2_and_T_from_rho_Ye_P.c
@@ -10,8 +10,8 @@ ghl_error_codes_t NRPyEOS_eps_cs2_and_T_from_rho_Ye_P(
       double *restrict eps,
       double *restrict cs2,
       double *restrict T) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_cs2_and_T_from_rho_Ye_P.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_cs2_and_T_from_rho_Ye_P.c
@@ -10,6 +10,10 @@ ghl_error_codes_t NRPyEOS_eps_cs2_and_T_from_rho_Ye_P(
       double *restrict eps,
       double *restrict cs2,
       double *restrict T) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[2] = {NRPyEOS_eps_key, NRPyEOS_cs2_key};
@@ -31,4 +35,5 @@ ghl_error_codes_t NRPyEOS_eps_cs2_and_T_from_rho_Ye_P(
   *eps = outvars[0];
   *cs2 = outvars[1];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_from_rho_Ye_T.c
@@ -8,8 +8,8 @@ ghl_error_codes_t NRPyEOS_eps_from_rho_Ye_T(
       const double Y_e,
       const double T,
       double *restrict eps) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_eps_from_rho_Ye_T.c
@@ -8,6 +8,10 @@ ghl_error_codes_t NRPyEOS_eps_from_rho_Ye_T(
       const double Y_e,
       const double T,
       double *restrict eps) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[1] = {NRPyEOS_eps_key};
@@ -26,4 +30,5 @@ ghl_error_codes_t NRPyEOS_eps_from_rho_Ye_T(
   // Step 5: Update output variables
   *eps = outvars[0];
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_from_rho_Ye_T_interpolate_n_quantities.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_from_rho_Ye_T_interpolate_n_quantities.c
@@ -11,8 +11,8 @@ ghl_error_codes_t NRPyEOS_from_rho_Ye_T_interpolate_n_quantities(
       const double T,
       const int *restrict tablevars_keys,
       double *restrict tablevars) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_from_rho_Ye_T_interpolate_n_quantities.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_from_rho_Ye_T_interpolate_n_quantities.c
@@ -11,6 +11,10 @@ ghl_error_codes_t NRPyEOS_from_rho_Ye_T_interpolate_n_quantities(
       const double T,
       const int *restrict tablevars_keys,
       double *restrict tablevars) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   if(!n) return ghl_success;
 
@@ -50,4 +54,5 @@ ghl_error_codes_t NRPyEOS_from_rho_Ye_T_interpolate_n_quantities(
     tablevars[i] = tablevar_out;
   }
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_from_rho_Ye_aux_find_T_and_interpolate_n_quantities.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_from_rho_Ye_aux_find_T_and_interpolate_n_quantities.c
@@ -14,6 +14,10 @@ ghl_error_codes_t NRPyEOS_from_rho_Ye_aux_find_T_and_interpolate_n_quantities(
       const int *restrict tablevars_keys,
       double *restrict tablevars,
       double *restrict T) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // This function will interpolate n table quantities from
   // (rho,Ye,aux). It replaces EOS_Omni calls with keytemp != 1
@@ -61,4 +65,5 @@ ghl_error_codes_t NRPyEOS_from_rho_Ye_aux_find_T_and_interpolate_n_quantities(
   // Then interpolate the quantities we want from (rho,Ye,T)
   NRPyEOS_from_rho_Ye_T_interpolate_n_quantities(eos, n, rho, Y_e, *T, tablevars_keys, tablevars);
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_from_rho_Ye_aux_find_T_and_interpolate_n_quantities.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_from_rho_Ye_aux_find_T_and_interpolate_n_quantities.c
@@ -14,8 +14,8 @@ ghl_error_codes_t NRPyEOS_from_rho_Ye_aux_find_T_and_interpolate_n_quantities(
       const int *restrict tablevars_keys,
       double *restrict tablevars,
       double *restrict T) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_muhat_mue_mup_mun_Xn_and_Xp_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_muhat_mue_mup_mun_Xn_and_Xp_from_rho_Ye_T.c
@@ -13,8 +13,8 @@ ghl_error_codes_t NRPyEOS_muhat_mue_mup_mun_Xn_and_Xp_from_rho_Ye_T(
       double *restrict mu_n,
       double *restrict X_n,
       double *restrict X_p) {
-#ifndef GRHAYL_USE_HDF5
-  HDF5_ERROR_IF_USED;
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
   return ghl_error_hdf5_is_disabled;
 #else
 

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_muhat_mue_mup_mun_Xn_and_Xp_from_rho_Ye_T.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_muhat_mue_mup_mun_Xn_and_Xp_from_rho_Ye_T.c
@@ -13,6 +13,10 @@ ghl_error_codes_t NRPyEOS_muhat_mue_mup_mun_Xn_and_Xp_from_rho_Ye_T(
       double *restrict mu_n,
       double *restrict X_n,
       double *restrict X_p) {
+#ifndef GRHAYL_USE_HDF5
+  HDF5_ERROR_IF_USED;
+  return ghl_error_hdf5_is_disabled;
+#else
 
   // Step 1: Set EOS table keys
   const int keys[6] = {NRPyEOS_muhat_key,NRPyEOS_mu_e_key,NRPyEOS_mu_p_key,NRPyEOS_mu_n_key,NRPyEOS_X_n_key,NRPyEOS_X_p_key};
@@ -37,4 +41,5 @@ ghl_error_codes_t NRPyEOS_muhat_mue_mup_mun_Xn_and_Xp_from_rho_Ye_T(
   *X_p = outvars[5];
 
   return ghl_success;
+#endif
 }

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_tabulated_helpers.h
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_tabulated_helpers.h
@@ -1,4 +1,4 @@
-#ifdef GRHAYL_DISABLE_HDF5
+#ifndef GRHAYL_DISABLE_HDF5
 /*
  * (c) 2022 Leo Werneck
  *

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_tabulated_helpers.h
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_tabulated_helpers.h
@@ -1,4 +1,4 @@
-#ifdef GRHAYL_USE_HDF5
+#ifdef GRHAYL_DISABLE_HDF5
 /*
  * (c) 2022 Leo Werneck
  *

--- a/GRHayL/GRHayL_Core/read_error_codes.c
+++ b/GRHayL/GRHayL_Core/read_error_codes.c
@@ -69,5 +69,8 @@ void ghl_read_error_codes(
     case ghl_error_newman_invalid_discriminant:
       ghl_abort("Found negative discriminant inside Newman1D Con2Prim");
       break;
+    case ghl_error_hdf5_is_disabled:
+      ghl_abort("HDF5 is disabled, so tabulated EOS functions are not allowed");
+      break;
   }
 }

--- a/GRHayL/include/ghl.h
+++ b/GRHayL/include/ghl.h
@@ -19,10 +19,6 @@
 #define M_PI 3.141592653589793238462643383279502884L
 #endif
 
-#ifndef GRHAYL_DISABLE_HDF5
-#define GRHAYL_USE_HDF5
-#endif
-
 #ifdef __cplusplus
 #ifndef restrict
 #define restrict __restrict__

--- a/GRHayL/include/ghl.h
+++ b/GRHayL/include/ghl.h
@@ -53,6 +53,7 @@ typedef enum {
   ghl_error_invalid_utsq,
   ghl_error_invalid_Z,
   ghl_error_newman_invalid_discriminant,
+  ghl_error_hdf5_is_disabled,
 } ghl_error_codes_t;
 
 typedef enum {

--- a/GRHayL/include/ghl_nrpyeos_tabulated.h
+++ b/GRHayL/include/ghl_nrpyeos_tabulated.h
@@ -5,7 +5,7 @@
 
 #ifndef GRHAYL_USE_HDF5
 #define HDF5_ERROR_IF_USED \
-  ghl_error("HDF5 is disabled, so this function cannot be used\n")
+  ghl_error("HDF5 is disabled, so this function cannot be used\n");
 #else
 
 #include <string.h>

--- a/GRHayL/include/ghl_nrpyeos_tabulated.h
+++ b/GRHayL/include/ghl_nrpyeos_tabulated.h
@@ -3,8 +3,8 @@
 
 #include "ghl.h"
 
-#ifndef GRHAYL_USE_HDF5
-#define HDF5_ERROR_IF_USED \
+#ifdef GRHAYL_DISABLE_HDF5
+#define GRHAYL_HDF5_ERROR_IF_USED \
   ghl_error("HDF5 is disabled, so this function cannot be used\n");
 #else
 
@@ -46,7 +46,7 @@ static const char table_var_names[NRPyEOS_ntablekeys][10] = {
   "Xa","Xh","Xn","Xp","Abar","Zbar","Gamma"
 };
 //********************************************
-#endif // GRHAYL_USE_HDF5
+#endif // GRHAYL_DISABLE_HDF5
 
 // Function prototypes
 void NRPyEOS_read_table_set_EOS_params(

--- a/Unit_Tests/tabulated_eos_unit_test_helpers.c
+++ b/Unit_Tests/tabulated_eos_unit_test_helpers.c
@@ -5,6 +5,10 @@ double get_table_quantity(
       const double rho,
       const double Y_e,
       const double T ) {
+#ifdef GRHAYL_DISABLE_HDF5
+  GRHAYL_HDF5_ERROR_IF_USED;
+  return NAN;
+#else
   switch (which_var) {
     case NRPyEOS_press_key:
       return rho + Y_e + T;
@@ -48,4 +52,5 @@ double get_table_quantity(
       ghl_error("Invalid variable %d\n", which_var);
       return -1;
   }
+#endif
 }

--- a/Unit_Tests/unit_test_code_error.c
+++ b/Unit_Tests/unit_test_code_error.c
@@ -71,6 +71,7 @@ int main(int argc, char **argv) {
       Fermi_Dirac_integral = NRPyLeakage_Fermi_Dirac_integrals(-1, 1e-2);
       break;
   }
+  (void)Fermi_Dirac_integral; // TODO: I'm not sure that's the way to go here
 
   ghl_metric_quantities ADM_metric;
   ghl_primitive_quantities prims;
@@ -106,6 +107,7 @@ int main(int argc, char **argv) {
         ghl_read_error_codes(error);
       break;
   }
+#ifndef GRHAYL_DISABLE_HDF5
 /*
 rho: 2.718281828459045e+00, 1.096633158428459e+03
  T : 2.718281828459045e+00, 1.484131591025766e+02
@@ -340,6 +342,7 @@ Y_e: 1.000000000000000e+00, 3.000000000000000e+00
   if(test_key > 33 && test_key < 61) {
     read_table_error_test(test_key);
   }
+#endif
 
   /*
      initialize_*_eos_functions_and_params::
@@ -369,6 +372,7 @@ Y_e: 1.000000000000000e+00, 3.000000000000000e+00
             neos, rho_ppoly, Gamma_ppoly,
             k_ppoly0, Gamma_th, &hybrid_eos);
       break;
+#ifndef GRHAYL_DISABLE_HDF5
     case 63:
       ghl_initialize_tabulated_eos_functions_and_params(
             tablepath,
@@ -376,6 +380,7 @@ Y_e: 1.000000000000000e+00, 3.000000000000000e+00
             Y_e_atm, Y_e_min, Y_e_max,
             T_atm, T_min, T_max, &tab_eos);
       break;
+#endif
     case 64:
       ghl_initialize_simple_eos_functions_and_params(
             rho_b_atm, rho_b_max, rho_b_min,
@@ -388,6 +393,7 @@ Y_e: 1.000000000000000e+00, 3.000000000000000e+00
             neos, rho_ppoly, Gamma_ppoly,
             k_ppoly0, Gamma_th, &hybrid_eos);
       break;
+#ifndef GRHAYL_DISABLE_HDF5
     case 66:
       ghl_initialize_tabulated_eos_functions_and_params(
             tablepath,
@@ -395,6 +401,7 @@ Y_e: 1.000000000000000e+00, 3.000000000000000e+00
             Y_e_atm, Y_e_min, Y_e_max,
             T_atm, T_min, T_max, &tab_eos);
       break;
+#endif
     case 67:
       ghl_initialize_simple_eos_functions_and_params(
             rho_b_atm, rho_b_min, rho_b_max,
@@ -407,6 +414,7 @@ Y_e: 1.000000000000000e+00, 3.000000000000000e+00
             press_atm, press_max, press_min,
             Gamma_th, &hybrid_eos);
       break;
+#ifndef GRHAYL_DISABLE_HDF5
     case 69:
       ghl_initialize_tabulated_eos_functions_and_params(
             tablepath,
@@ -435,15 +443,19 @@ Y_e: 1.000000000000000e+00, 3.000000000000000e+00
             Y_e_atm, Y_e_min, Y_e_max,
             T_atm, T_max, T_min, &tab_eos);
       break;
+#endif
   }
 
+#ifndef GRHAYL_DISABLE_HDF5
   printf("Code failure test has failed for code test %d\n", test_key);
   printf("We shouldn't be here, so I'll get rid of some compilation warnings :)\n"
          "%e %d %e %e %e %e\n", Fermi_Dirac_integral, speed_limited, rho, Y_e, eps, T);
+#endif
   return 0;
 }
 // clang-format on
 
+#ifndef GRHAYL_DISABLE_HDF5
 void create_dataset(char *name, int dim, hid_t datatype_id, hid_t file_id) {
   hsize_t dims[dim];
   for(int i=0;i<dim;i++) {
@@ -464,7 +476,9 @@ void create_dataset(char *name, int dim, hid_t datatype_id, hid_t file_id) {
   H5Dclose(dataset_id);
   H5Sclose(dataspace_id);
 }
+#endif
 
+#ifndef GRHAYL_DISABLE_HDF5
 void read_table_error_test(int test_key) {
 
   test_key -= 34;
@@ -509,3 +523,4 @@ void read_table_error_test(int test_key) {
   ghl_eos_parameters eos;
   NRPyEOS_read_table_set_EOS_params("test.h5", &eos);
 }
+#endif

--- a/Unit_Tests/unit_test_tabulated_eos.c
+++ b/Unit_Tests/unit_test_tabulated_eos.c
@@ -5,6 +5,7 @@
  * (c) 2023 Leo Werneck
  */
 int main(int argc, char **argv) {
+#ifndef GRHAYL_DISABLE_HDF5
 
   double rtol = 1.5e-12;
   double atol = 1e-14;
@@ -603,6 +604,7 @@ int main(int argc, char **argv) {
   ghl_tabulated_free_memory(&eos);
 
   ghl_info("Test finished with no errors!\n");
+#endif
 
   // All done!
   return 0;


### PR DESCRIPTION
This PR fixes the `--nohdf5` configuration flag, which previously didn't properly disable HDF5. Changes include:

* Removing macro `GRHAYL_USE_HDF5`, directly using `GRHAYL_DISABLE_HDF5` instead.
  - This actually has the bonus of being friendlier to IDEs/text editors/LSPs.
* Adding a new error code `grhayl_error_hdf5_is_disabled`.
* Making sure all functions that rely on tabulated EOS quantities are properly disabled.