### PR TITLE
Minor Fixes

### DIFF
--- a/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D_entropy.c
+++ b/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D_entropy.c
@@ -68,7 +68,7 @@ ghl_error_codes_t ghl_hybrid_Palenzuela1D_entropy(
       ghl_primitive_quantities *restrict prims,
       ghl_con2prim_diagnostics *restrict diagnostics) {
 
-  diagnostics->which_routine = Palenzuela1D;
+  diagnostics->which_routine = Palenzuela1D_entropy;
   return ghl_hybrid_Palenzuela1D(compute_rho_P_eps_W_entropy,
                                  params,
                                  eos,

--- a/GRHayL/EOS/Tabulated/NRPyEOS_tabulated_compute_Ye_of_rho_beq_constant_T.c
+++ b/GRHayL/EOS/Tabulated/NRPyEOS_tabulated_compute_Ye_of_rho_beq_constant_T.c
@@ -36,7 +36,7 @@ static int find_left_index_uniform_array(
       const double *restrict x_arr,
       const double x) {
 
-  return (x - x_arr[0]) / (x_arr[1] - x_arr[0]) + 0.5;
+  return (x - x_arr[0]) / (x_arr[1] - x_arr[0]);
 }
 
 static int


### PR DESCRIPTION
This PR fixes a couple of minor issues in the beta-equlibrium function and an incorrect initialization of one of the member variables in the `ghl_con2prim_diagnostics` struct inside the hybrid version of the Palenzuela1D primitive-recovery routine.