### PR TITLE
Remove MIN/MAX Macros

### DIFF
--- a/.github/workflows/github-actions-MacOS-clang.yml
+++ b/.github/workflows/github-actions-MacOS-clang.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [conservs, primitives, induction_gauge_rhs, HLL_flux, reconstruction, flux_source]
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [apply_conservative_limits, con2prim_multi_method_hybrid, enforce_primitive_limits_and_compute_u0, compute_conservs_and_Tmunu]
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_failure]
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -173,7 +173,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_flux, tabulated_flux]
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -203,7 +203,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [PLM_reconstruction, WENOZ_reconstruction]
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -232,7 +232,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [nrpyleakage_optically_thin_gas, nrpyleakage_constant_density_sphere, nrpyleakage_luminosities]
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -260,7 +260,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -302,7 +302,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -333,7 +333,7 @@ jobs:
       matrix:
         metric: [BSSN, ADM]
         centering: [ccc, vvv]
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
         exclude:
           - metric: BSSN
             centering: vvv
@@ -365,7 +365,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/github-actions-MacOS-clang.yml
+++ b/.github/workflows/github-actions-MacOS-clang.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [conservs, primitives, induction_gauge_rhs, HLL_flux, reconstruction, flux_source]
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [apply_conservative_limits, con2prim_multi_method_hybrid, enforce_primitive_limits_and_compute_u0, compute_conservs_and_Tmunu]
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_failure]
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -173,7 +173,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_flux, tabulated_flux]
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -203,7 +203,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [PLM_reconstruction, WENOZ_reconstruction]
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -232,7 +232,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [nrpyleakage_optically_thin_gas, nrpyleakage_constant_density_sphere, nrpyleakage_luminosities]
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -260,7 +260,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -302,7 +302,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -333,7 +333,7 @@ jobs:
       matrix:
         metric: [BSSN, ADM]
         centering: [ccc, vvv]
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
         exclude:
           - metric: BSSN
             centering: vvv
@@ -365,7 +365,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/github-actions-MacOS-clang.yml
+++ b/.github/workflows/github-actions-MacOS-clang.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [conservs, primitives, induction_gauge_rhs, HLL_flux, reconstruction, flux_source]
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [apply_conservative_limits, con2prim_multi_method_hybrid, enforce_primitive_limits_and_compute_u0, compute_conservs_and_Tmunu]
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_failure]
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -173,7 +173,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_flux, tabulated_flux]
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -203,7 +203,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [PLM_reconstruction, WENOZ_reconstruction]
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -232,7 +232,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [nrpyleakage_optically_thin_gas, nrpyleakage_constant_density_sphere, nrpyleakage_luminosities]
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -260,7 +260,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -302,7 +302,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -333,7 +333,7 @@ jobs:
       matrix:
         metric: [BSSN, ADM]
         centering: [ccc, vvv]
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
         exclude:
           - metric: BSSN
             centering: vvv
@@ -365,7 +365,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/github-actions-MacOS-gcc.yml
+++ b/.github/workflows/github-actions-MacOS-gcc.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [conservs, primitives, induction_gauge_rhs, HLL_flux, reconstruction, flux_source]
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [apply_conservative_limits, con2prim_multi_method_hybrid, enforce_primitive_limits_and_compute_u0, compute_conservs_and_Tmunu]
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_failure]
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -179,7 +179,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_flux, tabulated_flux]
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -210,7 +210,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [PLM_reconstruction, WENOZ_reconstruction]
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -240,7 +240,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [nrpyleakage_optically_thin_gas, nrpyleakage_constant_density_sphere, nrpyleakage_luminosities]
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -269,7 +269,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -312,7 +312,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -345,7 +345,7 @@ jobs:
       matrix:
         metric: [BSSN, ADM]
         centering: [ccc, vvv]
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
         exclude:
           - metric: BSSN
             centering: vvv
@@ -379,7 +379,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-latest]
+        os: [macos-14, macos-15, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/github-actions-MacOS-gcc.yml
+++ b/.github/workflows/github-actions-MacOS-gcc.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [conservs, primitives, induction_gauge_rhs, HLL_flux, reconstruction, flux_source]
-        os: [macos-14, tmacos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/github-actions-MacOS-gcc.yml
+++ b/.github/workflows/github-actions-MacOS-gcc.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [conservs, primitives, induction_gauge_rhs, HLL_flux, reconstruction, flux_source]
-        os: [macos-14-large, macos-14, tmacos-latest]
+        os: [macos-14, tmacos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [apply_conservative_limits, con2prim_multi_method_hybrid, enforce_primitive_limits_and_compute_u0, compute_conservs_and_Tmunu]
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_failure]
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -179,7 +179,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_flux, tabulated_flux]
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -210,7 +210,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [PLM_reconstruction, WENOZ_reconstruction]
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -240,7 +240,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [nrpyleakage_optically_thin_gas, nrpyleakage_constant_density_sphere, nrpyleakage_luminosities]
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -269,7 +269,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -312,7 +312,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -345,7 +345,7 @@ jobs:
       matrix:
         metric: [BSSN, ADM]
         centering: [ccc, vvv]
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
         exclude:
           - metric: BSSN
             centering: vvv
@@ -379,7 +379,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-large, macos-14, macos-latest]
+        os: [macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/github-actions-MacOS-gcc.yml
+++ b/.github/workflows/github-actions-MacOS-gcc.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [conservs, primitives, induction_gauge_rhs, HLL_flux, reconstruction, flux_source]
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, tmacos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [apply_conservative_limits, con2prim_multi_method_hybrid, enforce_primitive_limits_and_compute_u0, compute_conservs_and_Tmunu]
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_failure]
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -179,7 +179,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [hybrid_flux, tabulated_flux]
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -210,7 +210,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [PLM_reconstruction, WENOZ_reconstruction]
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -240,7 +240,7 @@ jobs:
       fail-fast: false
       matrix:
         test-function: [nrpyleakage_optically_thin_gas, nrpyleakage_constant_density_sphere, nrpyleakage_luminosities]
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -269,7 +269,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -312,7 +312,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -345,7 +345,7 @@ jobs:
       matrix:
         metric: [BSSN, ADM]
         centering: [ccc, vvv]
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
         exclude:
           - metric: BSSN
             centering: vvv
@@ -379,7 +379,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-14-large, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D.c
+++ b/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D.c
@@ -69,7 +69,7 @@ ghl_error_codes_t ghl_hybrid_Palenzuela1D(
 
   double SU[3], B_squared, S_squared, BdotS;
   compute_SU_Bsq_Ssq_BdotS(ADM_metric, cons_undens, prims, SU, &B_squared, &S_squared, &BdotS);
-  const double tau = MAX(cons_undens->tau, eos->tau_atm);
+  const double tau = fmax(cons_undens->tau, eos->tau_atm);
 
   // Set specific quantities for this routine (Eq. A7 of [1])
   fparams_struct fparams;

--- a/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_energy.c
+++ b/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_energy.c
@@ -26,7 +26,7 @@ static ghl_error_codes_t ghl_newman_energy(
   int AtStep=0;
 
   // Floor tau
-  const double tau = MAX(con->tau, eos->tau_atm);
+  const double tau = fmax(con->tau, eos->tau_atm);
 
   // d = 0.5( S^{2}*B^{2} - (B.S)^{2} ) (eq. 5.7 in Newman & Hamlin 2014)
   double d = 0.5*(S_squared*B_squared-BdotS*BdotS);
@@ -77,7 +77,7 @@ static ghl_error_codes_t ghl_newman_energy(
     const double vsq   = (zsq * S_squared + (z+Eps)*BdotSsq)/(zsq*Epssq);
 
     // Impose physical limits and compute W
-    invW = MIN(MAX(sqrt(1.0-vsq), 1.0/params->max_Lorentz_factor), 1.0);
+    invW = fmin(fmax(sqrt(1.0-vsq), 1.0/params->max_Lorentz_factor), 1.0);
     W    = 1.0/invW;
 
     // Set the prims (eps is computed as in Palenzuela et al.)
@@ -117,7 +117,7 @@ static ghl_error_codes_t ghl_newman_energy(
     const double Epssq = Eps*Eps;
     const double zsq   = z*z;
     const double vsq   = (zsq * S_squared + (z+Eps)*BdotSsq)/(zsq*Epssq);
-    invW               = MIN(MAX(sqrt(1.0-vsq), 1.0/params->max_Lorentz_factor), 1.0);
+    invW               = fmin(fmax(sqrt(1.0-vsq), 1.0/params->max_Lorentz_factor), 1.0);
     W                  = 1.0/invW;
   }
 

--- a/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_entropy.c
+++ b/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_entropy.c
@@ -26,7 +26,7 @@ static ghl_error_codes_t ghl_newman_entropy(
   int AtStep=0;
 
   // Floor tau
-  const double tau = MAX(con->tau, eos->tau_atm);
+  const double tau = fmax(con->tau, eos->tau_atm);
 
   // d = 0.5( S^{2}*B^{2} - (B.S)^{2} ) (eq. 5.7 in Newman & Hamlin 2014)
   double d = 0.5*(S_squared*B_squared-BdotS*BdotS);
@@ -72,7 +72,7 @@ static ghl_error_codes_t ghl_newman_entropy(
     const double vsq   = (zsq * S_squared + (z+Eps)*BdotSsq)/(zsq*Epssq);
 
     // Impose physical limits and compute W
-    invW = MIN(MAX(sqrt(1.0-vsq), 1.0/params->max_Lorentz_factor), 1.0);
+    invW = fmin(fmax(sqrt(1.0-vsq), 1.0/params->max_Lorentz_factor), 1.0);
     W    = 1.0/invW;
 
     // Then compute rho = D/W
@@ -109,7 +109,7 @@ static ghl_error_codes_t ghl_newman_entropy(
     const double Epssq = Eps*Eps;
     const double zsq   = z*z;
     const double vsq   = (zsq * S_squared + (z+Eps)*BdotSsq)/(zsq*Epssq);
-    invW               = MIN(MAX(sqrt(1.0-vsq), 1.0/params->max_Lorentz_factor), 1.0);
+    invW               = fmin(fmax(sqrt(1.0-vsq), 1.0/params->max_Lorentz_factor), 1.0);
     W                  = 1.0/invW;
   }
 

--- a/GRHayL/Con2Prim/Tabulated/Palenzuela1D/tabulated_Palenzuela1D.c
+++ b/GRHayL/Con2Prim/Tabulated/Palenzuela1D/tabulated_Palenzuela1D.c
@@ -69,7 +69,7 @@ ghl_error_codes_t ghl_tabulated_Palenzuela1D(
 
   double SU[3], B_squared, S_squared, BdotS;
   compute_SU_Bsq_Ssq_BdotS(ADM_metric, cons_undens, prims, SU, &B_squared, &S_squared, &BdotS);
-  const double tau = MAX(cons_undens->tau, eos->tau_atm);
+  const double tau = fmax(cons_undens->tau, eos->tau_atm);
 
   // Set specific quantities for this routine (Eq. A7 of [1])
   fparams_struct fparams;

--- a/GRHayL/Con2Prim/Tabulated/Tabulated_CerdaDuran2D.c
+++ b/GRHayL/Con2Prim/Tabulated/Tabulated_CerdaDuran2D.c
@@ -347,7 +347,7 @@ void NR_2D_WT(
       }
 
     }
-    maxerror = MAX(error[0], error[1]);
+    maxerror = fmax(error[0], error[1]);
     count++;
 
     // termination criterion

--- a/GRHayL/Con2Prim/Tabulated/con2prim_CerdaDuran3D.cc
+++ b/GRHayL/Con2Prim/Tabulated/con2prim_CerdaDuran3D.cc
@@ -393,7 +393,7 @@ void NR_3D_WZT(
       }
 
     }
-    maxerror = MAX(error[0], error[1]);
+    maxerror = fmax(error[0], error[1]);
     count++;
 
     // termination criterion

--- a/GRHayL/Con2Prim/apply_conservative_limits.c
+++ b/GRHayL/Con2Prim/apply_conservative_limits.c
@@ -36,7 +36,7 @@ void ghl_apply_conservative_limits(
     tau_fluid_term3 = (B2*sdots - SQR(BdotS))*0.5/(ADM_metric->sqrt_detgamma*SQR(Wmin+B2));
   }
 
-  cons->tau = MAX(cons->tau, eos->tau_atm);
+  cons->tau = fmax(cons->tau, eos->tau_atm);
 
   //tau fix, applicable when B==0 and B!=0:
   if(cons->tau < half_psi6_B2) {

--- a/GRHayL/Con2Prim/enforce_primitive_limits_and_compute_u0.c
+++ b/GRHayL/Con2Prim/enforce_primitive_limits_and_compute_u0.c
@@ -18,7 +18,7 @@ ghl_error_codes_t ghl_enforce_primitive_limits_and_compute_u0(
     case ghl_eos_hybrid:
     {
       // Apply floors and ceilings to rho
-      prims->rho = MIN(MAX(prims->rho, eos->rho_min), eos->rho_max);
+      prims->rho = fmin(fmax(prims->rho, eos->rho_min), eos->rho_max);
 
       // Pressure and epsilon must be recomputed
       // Compute P and eps
@@ -70,10 +70,10 @@ ghl_error_codes_t ghl_enforce_primitive_limits_and_compute_u0(
 
     case ghl_eos_simple:
       // Apply floors and ceilings to rho
-      prims->rho = MIN(MAX(prims->rho, eos->rho_min), eos->rho_max);
+      prims->rho = fmin(fmax(prims->rho, eos->rho_min), eos->rho_max);
 
       // Apply floors and ceilings to P
-      prims->press = MIN(MAX(prims->press, eos->press_min), eos->press_max);
+      prims->press = fmin(fmax(prims->press, eos->press_min), eos->press_max);
 
       // Now recompute eps and, if needed, entropy
       prims->eps = prims->press / (prims->rho * (eos->Gamma_th - 1.0));

--- a/GRHayL/Con2Prim/utils_Palenzuela1D.h
+++ b/GRHayL/Con2Prim/utils_Palenzuela1D.h
@@ -34,7 +34,7 @@ compute_rho_W_from_x_and_conservatives(
 
   // Step 2: Compute W
   double Wminus2 = 1.0 - ( x*x*r + (2*x+s)*t*t )/ (x*x*(x+s)*(x+s));
-  Wminus2        = MIN(MAX(Wminus2, params->inv_sq_max_Lorentz_factor ), 1.0);
+  Wminus2        = fmin(fmax(Wminus2, params->inv_sq_max_Lorentz_factor ), 1.0);
   const double W = pow(Wminus2, -0.5);
 
   // Step 3: Compute rho

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_tabulated_helpers.h
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_tabulated_helpers.h
@@ -7,6 +7,16 @@
  * Source: https://bitbucket.org/zelmani/eosdrivercxx
  */
 
+static inline __attribute__((always_inline))
+int imin(int a, int b) {
+  return a < b ? a : b;
+}
+
+static inline __attribute__((always_inline))
+int imax(int a, int b) {
+  return a > b ? a : b;
+}
+
 //------------------------------------------
 static inline __attribute__((always_inline))
 ghl_error_codes_t NRPyEOS_checkbounds(
@@ -71,9 +81,9 @@ void NRPyEOS_get_interp_spots(
   int iy = 1 + (int)( (y - eos->table_logT[0] - 1.0e-10) * eos->dtempi );
   int iz = 1 + (int)( (z - eos->table_Y_e[0]     - 1.0e-10) * eos->dyei  );
 
-  ix = MAX( 1, MIN( ix, eos->N_rho -1 ) );
-  iy = MAX( 1, MIN( iy, eos->N_T-1 ) );
-  iz = MAX( 1, MIN( iz, eos->N_Ye  -1 ) );
+  ix = imax( 1, imin( ix, eos->N_rho -1 ) );
+  iy = imax( 1, imin( iy, eos->N_T-1 ) );
+  iz = imax( 1, imin( iz, eos->N_Ye  -1 ) );
 
   idx[0] = NRPyEOS_ntablekeys*(ix     + eos->N_rho*(iy     + eos->N_T*iz    ));
   idx[1] = NRPyEOS_ntablekeys*((ix-1) + eos->N_rho*(iy     + eos->N_T*iz    ));
@@ -219,8 +229,8 @@ ghl_error_codes_t NRPyEOS_bisection(
 
   // otherwise, proceed finding extrema for applying bisection method.
   lt = lt0;
-  lt1 = MIN(lt0 + dlt0p,ltmax);
-  lt2 = MAX(lt0 + dlt0m,ltmin);
+  lt1 = fmin(lt0 + dlt0p,ltmax);
+  lt2 = fmax(lt0 + dlt0m,ltmin);
 
   NRPyEOS_get_interp_spots(eos,lr,lt1,ye,&delx,&dely,&delz,idx);
   NRPyEOS_linterp_one(eos,idx,delx,dely,delz,&f1a,iv);
@@ -234,8 +244,8 @@ ghl_error_codes_t NRPyEOS_bisection(
   // iterate until we bracket the right eps, but enforce
   // dE/dt > 0, so eps(lt1) > eps(lt2)
   while(f1*f2 >= 0.0) {
-    lt1 = MIN(lt1 + dltp,ltmax);
-    lt2 = MAX(lt2 + dltm,ltmin);
+    lt1 = fmin(lt1 + dltp,ltmax);
+    lt2 = fmax(lt2 + dltm,ltmin);
     NRPyEOS_get_interp_spots(eos,lr,lt1,ye,&delx,&dely,&delz,idx);
     NRPyEOS_linterp_one(eos,idx,delx,dely,delz,&f1a,iv);
 
@@ -314,8 +324,8 @@ ghl_error_codes_t NRPyEOS_findtemp_from_any(
 
   double oerr = 1.0e90;
   double fac  = 1.0;
-  const int irho = MIN(MAX(1 + (int)(( lr - eos->table_logrho[0] - 1.0e-12) * eos->drhoi),1),eos->N_rho-1);
-  const int iye  = MIN(MAX(1 + (int)(( ye - eos->table_Y_e[0]    - 1.0e-12) * eos->dyei ),1),eos->N_Ye -1);
+  const int irho = imin(imax(1 + (int)(( lr - eos->table_logrho[0] - 1.0e-12) * eos->drhoi),1),eos->N_rho-1);
+  const int iye  = imin(imax(1 + (int)(( ye - eos->table_Y_e[0]    - 1.0e-12) * eos->dyei ),1),eos->N_Ye -1);
 
   /* ******* if temp low for high density, switch directly to bisection.
      Verifying Newton-Raphson result evaluating the derivative.
@@ -327,7 +337,7 @@ ghl_error_codes_t NRPyEOS_findtemp_from_any(
 
     // step 2: check if the two bounding values of the temperature
     //         give eps values that enclose the new eps.
-    const int itemp = MIN(MAX(1 + (int)(( lt - eos->table_logT[0] - 1.0e-12) * eos->dtempi),1),eos->N_T-1);
+    const int itemp = imin(imax(1 + (int)(( lt - eos->table_logT[0] - 1.0e-12) * eos->dtempi),1),eos->N_T-1);
 
     double tablevart1, tablevart2;
     // lower temperature
@@ -391,7 +401,7 @@ ghl_error_codes_t NRPyEOS_findtemp_from_any(
     //       given by Newton-Raphson.
     if(ldt > (ltmax-ltmin) / 12.0 ) shouldgotobisection = true;
 
-    ltn = MIN(MAX(lt + ldt,ltmin),ltmax);
+    ltn = fmin(fmax(lt + ldt,ltmin),ltmax);
     lt = ltn;
 
     NRPyEOS_get_interp_spots(eos, lr, lt, ye, &delx, &dely, &delz, idx);

--- a/GRHayL/Neutrinos/NRPyLeakage/NRPyLeakage_compute_neutrino_luminosities.c
+++ b/GRHayL/Neutrinos/NRPyLeakage/NRPyLeakage_compute_neutrino_luminosities.c
@@ -90,9 +90,9 @@ void NRPyLeakage_compute_neutrino_luminosities(
   const double tmp_41 = NRPyLeakage_Fermi_Dirac_integrals(3, tmp_6);
   const double tmp_42 = NRPyLeakage_N_A*NRPyLeakage_sigma_0*((T)*(T))*rho_cgs/((NRPyLeakage_m_e_c2)*(NRPyLeakage_m_e_c2));
   const double tmp_43 = tmp_40*tmp_42/tmp_41;
-  const double tmp_45 = (1 - Y_e)*((5.0/24.0)*tmp_7 + 1.0/24.0)/((2.0/3.0)*MAX(mu_n*tmp_0, 0) + 1);
+  const double tmp_45 = (1 - Y_e)*((5.0/24.0)*tmp_7 + 1.0/24.0)/((2.0/3.0)*fmax(mu_n*tmp_0, 0) + 1);
   const double tmp_46 = ((NRPyLeakage_C_V - 1)*(NRPyLeakage_C_V - 1));
-  const double tmp_47 = Y_e*((1.0/6.0)*tmp_46 + (5.0/24.0)*tmp_7)/((2.0/3.0)*MAX(mu_p*tmp_0, 0) + 1);
+  const double tmp_47 = Y_e*((1.0/6.0)*tmp_46 + (5.0/24.0)*tmp_7)/((2.0/3.0)*fmax(mu_p*tmp_0, 0) + 1);
   const double tmp_48 = (3.0/4.0)*tmp_7 + 1.0/4.0;
   const double tmp_49 = 4*((T)*(T)*(T)*(T))*tmp_8;
   const double tmp_50 = 6/NRPyLeakage_units_geom_to_cgs_L;
@@ -104,7 +104,7 @@ void NRPyLeakage_compute_neutrino_luminosities(
   const double tmp_57 = tmp_55/tmp_56;
   const double tmp_60 = NRPyLeakage_Fermi_Dirac_integrals(3, 0);
   const double tmp_61 = NRPyLeakage_Fermi_Dirac_integrals(5, 0)/tmp_60;
-  lum->nue = tmp_39*tmp_52/(((tau->nue[1])*(tau->nue[1]))*tmp_39*tmp_50/((EnsureFinite(tmp_43*tmp_45) + EnsureFinite(tmp_43*tmp_47) + EnsureFinite(Y_np*tmp_43*tmp_48/(exp(tmp_1 - tmp_40/NRPyLeakage_Fermi_Dirac_integrals(4, tmp_6)) + 1)))*MAX(tmp_41*tmp_49, 1.0000000000000001e-15)) + 1);
-  lum->anue = tmp_52*tmp_54/(((tau->anue[1])*(tau->anue[1]))*tmp_50*tmp_54/((EnsureFinite(tmp_42*tmp_45*tmp_57) + EnsureFinite(tmp_42*tmp_47*tmp_57) + EnsureFinite(Y_pn*tmp_42*tmp_48*tmp_57/(exp(-tmp_1 - tmp_55/NRPyLeakage_Fermi_Dirac_integrals(4, tmp_14)) + 1)))*MAX(tmp_49*tmp_56, 1.0000000000000001e-15)) + 1);
-  lum->nux = tmp_52*(tmp_11 + EnsureFinite(NRPyLeakage_enable_pair_nux_anux*tmp_37*EnsureFinite(NRPyLeakage_C1pC2_nux_anux*tmp_35/((exp(tmp_33) + 1)*(exp(tmp_33) + 1)))) + EnsureFinite(NRPyLeakage_enable_plasmon_nux_anux*tmp_27*EnsureFinite(tmp_26*tmp_46/((exp(tmp_21) + 1)*(exp(tmp_21) + 1)))))/(((tau->nux[1])*(tau->nux[1]))*tmp_39*tmp_50/((EnsureFinite(tmp_42*tmp_45*tmp_61) + EnsureFinite(tmp_42*tmp_47*tmp_61))*MAX(tmp_49*tmp_60, 1.0000000000000001e-15)) + 1);
+  lum->nue = tmp_39*tmp_52/(((tau->nue[1])*(tau->nue[1]))*tmp_39*tmp_50/((EnsureFinite(tmp_43*tmp_45) + EnsureFinite(tmp_43*tmp_47) + EnsureFinite(Y_np*tmp_43*tmp_48/(exp(tmp_1 - tmp_40/NRPyLeakage_Fermi_Dirac_integrals(4, tmp_6)) + 1)))*fmax(tmp_41*tmp_49, 1.0000000000000001e-15)) + 1);
+  lum->anue = tmp_52*tmp_54/(((tau->anue[1])*(tau->anue[1]))*tmp_50*tmp_54/((EnsureFinite(tmp_42*tmp_45*tmp_57) + EnsureFinite(tmp_42*tmp_47*tmp_57) + EnsureFinite(Y_pn*tmp_42*tmp_48*tmp_57/(exp(-tmp_1 - tmp_55/NRPyLeakage_Fermi_Dirac_integrals(4, tmp_14)) + 1)))*fmax(tmp_49*tmp_56, 1.0000000000000001e-15)) + 1);
+  lum->nux = tmp_52*(tmp_11 + EnsureFinite(NRPyLeakage_enable_pair_nux_anux*tmp_37*EnsureFinite(NRPyLeakage_C1pC2_nux_anux*tmp_35/((exp(tmp_33) + 1)*(exp(tmp_33) + 1)))) + EnsureFinite(NRPyLeakage_enable_plasmon_nux_anux*tmp_27*EnsureFinite(tmp_26*tmp_46/((exp(tmp_21) + 1)*(exp(tmp_21) + 1)))))/(((tau->nux[1])*(tau->nux[1]))*tmp_39*tmp_50/((EnsureFinite(tmp_42*tmp_45*tmp_61) + EnsureFinite(tmp_42*tmp_47*tmp_61))*fmax(tmp_49*tmp_60, 1.0000000000000001e-15)) + 1);
 }

--- a/GRHayL/Neutrinos/NRPyLeakage/NRPyLeakage_compute_neutrino_opacities.c
+++ b/GRHayL/Neutrinos/NRPyLeakage/NRPyLeakage_compute_neutrino_opacities.c
@@ -54,7 +54,7 @@ void NRPyLeakage_compute_neutrino_opacities(
   //   Y_pn = 1-Y_e;
   // }
   // // Step 3.a.ii: Make sure Y_{pn} is nonzero
-  // Y_pn = MAX(Y_pn,0.0);
+  // Y_pn = fmax(Y_pn,0.0);
 
   // // Step 3.b: Compute Y_{np} (Eq. A13 in https://adsabs.harvard.edu/pdf/1996A%26A...311..532R)
   // const double Y_np = exp(muhat/T) * Y_pn;
@@ -69,8 +69,8 @@ void NRPyLeakage_compute_neutrino_opacities(
   const double tmp_6 = NRPyLeakage_N_A*NRPyLeakage_sigma_0*((T)*(T))*rho_cgs/((NRPyLeakage_m_e_c2)*(NRPyLeakage_m_e_c2));
   const double tmp_7 = tmp_5*tmp_6/NRPyLeakage_Fermi_Dirac_integrals(2, tmp_4);
   const double tmp_9 = (5.0/24.0)*((NRPyLeakage_alpha)*(NRPyLeakage_alpha));
-  const double tmp_10 = (1 - Y_e)*(tmp_9 + 1.0/24.0)/((2.0/3.0)*MAX(mu_n*tmp_1, 0) + 1);
-  const double tmp_11 = Y_e*(tmp_9 + (1.0/6.0)*((NRPyLeakage_C_V - 1)*(NRPyLeakage_C_V - 1)))/((2.0/3.0)*MAX(mu_p*tmp_1, 0) + 1);
+  const double tmp_10 = (1 - Y_e)*(tmp_9 + 1.0/24.0)/((2.0/3.0)*fmax(mu_n*tmp_1, 0) + 1);
+  const double tmp_11 = Y_e*(tmp_9 + (1.0/6.0)*((NRPyLeakage_C_V - 1)*(NRPyLeakage_C_V - 1)))/((2.0/3.0)*fmax(mu_p*tmp_1, 0) + 1);
   const double tmp_12 = NRPyLeakage_Fermi_Dirac_integrals(5, tmp_4);
   const double tmp_13 = (3.0/4.0)*((NRPyLeakage_alpha)*(NRPyLeakage_alpha)) + 1.0/4.0;
   const double tmp_14 = Y_np*tmp_13/(exp(-tmp_12/tmp_5 + tmp_2) + 1);

--- a/GRHayL/Neutrinos/NRPyLeakage/NRPyLeakage_compute_neutrino_opacities_and_GRMHD_source_terms.c
+++ b/GRHayL/Neutrinos/NRPyLeakage/NRPyLeakage_compute_neutrino_opacities_and_GRMHD_source_terms.c
@@ -79,13 +79,13 @@ void NRPyLeakage_compute_neutrino_opacities_and_GRMHD_source_terms(
   const double tmp_36 = (1.0/3.0)*((M_PI)*(M_PI)*(M_PI))*NRPyLeakage_beta*pow(NRPyLeakage_gamma_0, 6)*tmp_24*tmp_26*((tmp_31)*(tmp_31)*(tmp_31))*(tmp_32 + 1)*exp(-tmp_32)/NRPyLeakage_alpha_fs;
   const double tmp_37 = NRPyLeakage_enable_plasmon_nue_anue*EnsureFinite(((NRPyLeakage_C_V)*(NRPyLeakage_C_V))*tmp_36/((exp(tmp_15 + tmp_35) + 1)*(exp(tmp_35 + tmp_6) + 1)));
   const double tmp_38 = tmp_12 + tmp_29 + tmp_37;
-  const double tmp_41 = (1 - Y_e)*((5.0/24.0)*tmp_7 + 1.0/24.0)/((2.0/3.0)*MAX(mu_n*tmp_0, 0) + 1);
+  const double tmp_41 = (1 - Y_e)*((5.0/24.0)*tmp_7 + 1.0/24.0)/((2.0/3.0)*fmax(mu_n*tmp_0, 0) + 1);
   const double tmp_42 = NRPyLeakage_N_A*NRPyLeakage_sigma_0*((T)*(T))*rho_cgs/((NRPyLeakage_m_e_c2)*(NRPyLeakage_m_e_c2));
   const double tmp_43 = NRPyLeakage_Fermi_Dirac_integrals(2, tmp_6);
   const double tmp_44 = NRPyLeakage_Fermi_Dirac_integrals(4, tmp_6);
   const double tmp_45 = tmp_44/tmp_43;
   const double tmp_47 = ((NRPyLeakage_C_V - 1)*(NRPyLeakage_C_V - 1));
-  const double tmp_48 = Y_e*((1.0/6.0)*tmp_47 + (5.0/24.0)*tmp_7)/((2.0/3.0)*MAX(mu_p*tmp_0, 0) + 1);
+  const double tmp_48 = Y_e*((1.0/6.0)*tmp_47 + (5.0/24.0)*tmp_7)/((2.0/3.0)*fmax(mu_p*tmp_0, 0) + 1);
   const double tmp_49 = tmp_42*tmp_48;
   const double tmp_50 = (3.0/4.0)*tmp_7 + 1.0/4.0;
   const double tmp_51 = NRPyLeakage_Fermi_Dirac_integrals(5, tmp_6);
@@ -119,8 +119,8 @@ void NRPyLeakage_compute_neutrino_opacities_and_GRMHD_source_terms(
   const double tmp_84 = tmp_63/tmp_83;
   const double tmp_86 = EnsureFinite(tmp_49*tmp_84) + EnsureFinite(tmp_41*tmp_42*tmp_84) + EnsureFinite(tmp_42*tmp_64*tmp_84);
   const double tmp_87 = NRPyLeakage_Fermi_Dirac_integrals(4, 0)/NRPyLeakage_Fermi_Dirac_integrals(2, 0);
-  *R_source = NRPyLeakage_amu*NRPyLeakage_units_cgs_to_geom_R*(-(tmp_11 + tmp_38)/(((tau->nue[0])*(tau->nue[0]))*tmp_56*(tmp_11 + tmp_38)/(tmp_53*MAX(tmp_43*tmp_55, 1.0000000000000001e-15)) + 1) + (tmp_38 + tmp_58)/(((tau->anue[0])*(tau->anue[0]))*tmp_56*(tmp_38 + tmp_58)/(tmp_65*MAX(tmp_55*tmp_60, 1.0000000000000001e-15)) + 1));
-  *Q_source = NRPyLeakage_units_cgs_to_geom_Q*(-tmp_76/(((tau->nue[1])*(tau->nue[1]))*tmp_56*tmp_76/(tmp_81*MAX(tmp_74*tmp_78, 1.0000000000000001e-15)) + 1) - tmp_82/(((tau->anue[1])*(tau->anue[1]))*tmp_56*tmp_82/(tmp_86*MAX(tmp_74*tmp_83, 1.0000000000000001e-15)) + 1) - 4*(tmp_66 + EnsureFinite(NRPyLeakage_enable_pair_nux_anux*tmp_68*EnsureFinite(NRPyLeakage_C1pC2_nux_anux*tmp_28/((exp(tmp_21) + 1)*(exp(tmp_21) + 1)))) + EnsureFinite(NRPyLeakage_enable_plasmon_nux_anux*tmp_69*EnsureFinite(tmp_36*tmp_47/((exp(tmp_35) + 1)*(exp(tmp_35) + 1)))))/(((tau->nux[1])*(tau->nux[1]))*tmp_56*tmp_76/(tmp_73*MAX(tmp_70*tmp_74, 1.0000000000000001e-15)) + 1));
+  *R_source = NRPyLeakage_amu*NRPyLeakage_units_cgs_to_geom_R*(-(tmp_11 + tmp_38)/(((tau->nue[0])*(tau->nue[0]))*tmp_56*(tmp_11 + tmp_38)/(tmp_53*fmax(tmp_43*tmp_55, 1.0000000000000001e-15)) + 1) + (tmp_38 + tmp_58)/(((tau->anue[0])*(tau->anue[0]))*tmp_56*(tmp_38 + tmp_58)/(tmp_65*fmax(tmp_55*tmp_60, 1.0000000000000001e-15)) + 1));
+  *Q_source = NRPyLeakage_units_cgs_to_geom_Q*(-tmp_76/(((tau->nue[1])*(tau->nue[1]))*tmp_56*tmp_76/(tmp_81*fmax(tmp_74*tmp_78, 1.0000000000000001e-15)) + 1) - tmp_82/(((tau->anue[1])*(tau->anue[1]))*tmp_56*tmp_82/(tmp_86*fmax(tmp_74*tmp_83, 1.0000000000000001e-15)) + 1) - 4*(tmp_66 + EnsureFinite(NRPyLeakage_enable_pair_nux_anux*tmp_68*EnsureFinite(NRPyLeakage_C1pC2_nux_anux*tmp_28/((exp(tmp_21) + 1)*(exp(tmp_21) + 1)))) + EnsureFinite(NRPyLeakage_enable_plasmon_nux_anux*tmp_69*EnsureFinite(tmp_36*tmp_47/((exp(tmp_35) + 1)*(exp(tmp_35) + 1)))))/(((tau->nux[1])*(tau->nux[1]))*tmp_56*tmp_76/(tmp_73*fmax(tmp_70*tmp_74, 1.0000000000000001e-15)) + 1));
   kappa->nue[0] = NRPyLeakage_units_geom_to_cgs_L*tmp_53;
   kappa->nue[1] = NRPyLeakage_units_geom_to_cgs_L*tmp_81;
   kappa->anue[0] = NRPyLeakage_units_geom_to_cgs_L*tmp_65;

--- a/GRHayL/Neutrinos/NRPyLeakage/NRPyLeakage_optical_depths_PathOfLeastResistance.c
+++ b/GRHayL/Neutrinos/NRPyLeakage/NRPyLeakage_optical_depths_PathOfLeastResistance.c
@@ -135,12 +135,12 @@ void NRPyLeakage_optical_depths_PathOfLeastResistance(
   const double tau_1_nux_i_j_km1 = tau_i_j_km1->nux[1] + ds_i_j_kmhalf*kappa_1_nux_i_j_kmhalf;
 
   // Step 8: Select path of least resistance
-  const double new_tau_0_nue_i_j_k  = MIN(MIN(MIN(MIN(MIN(tau_0_nue_ip1_j_k,tau_0_nue_im1_j_k),tau_0_nue_i_jp1_k),tau_0_nue_i_jm1_k),tau_0_nue_i_j_kp1),tau_0_nue_i_j_km1);
-  const double new_tau_1_nue_i_j_k  = MIN(MIN(MIN(MIN(MIN(tau_1_nue_ip1_j_k,tau_1_nue_im1_j_k),tau_1_nue_i_jp1_k),tau_1_nue_i_jm1_k),tau_1_nue_i_j_kp1),tau_1_nue_i_j_km1);
-  const double new_tau_0_anue_i_j_k = MIN(MIN(MIN(MIN(MIN(tau_0_anue_ip1_j_k,tau_0_anue_im1_j_k),tau_0_anue_i_jp1_k),tau_0_anue_i_jm1_k),tau_0_anue_i_j_kp1),tau_0_anue_i_j_km1);
-  const double new_tau_1_anue_i_j_k = MIN(MIN(MIN(MIN(MIN(tau_1_anue_ip1_j_k,tau_1_anue_im1_j_k),tau_1_anue_i_jp1_k),tau_1_anue_i_jm1_k),tau_1_anue_i_j_kp1),tau_1_anue_i_j_km1);
-  const double new_tau_0_nux_i_j_k  = MIN(MIN(MIN(MIN(MIN(tau_0_nux_ip1_j_k,tau_0_nux_im1_j_k),tau_0_nux_i_jp1_k),tau_0_nux_i_jm1_k),tau_0_nux_i_j_kp1),tau_0_nux_i_j_km1);
-  const double new_tau_1_nux_i_j_k  = MIN(MIN(MIN(MIN(MIN(tau_1_nux_ip1_j_k,tau_1_nux_im1_j_k),tau_1_nux_i_jp1_k),tau_1_nux_i_jm1_k),tau_1_nux_i_j_kp1),tau_1_nux_i_j_km1);
+  const double new_tau_0_nue_i_j_k  = fmin(fmin(fmin(fmin(fmin(tau_0_nue_ip1_j_k,tau_0_nue_im1_j_k),tau_0_nue_i_jp1_k),tau_0_nue_i_jm1_k),tau_0_nue_i_j_kp1),tau_0_nue_i_j_km1);
+  const double new_tau_1_nue_i_j_k  = fmin(fmin(fmin(fmin(fmin(tau_1_nue_ip1_j_k,tau_1_nue_im1_j_k),tau_1_nue_i_jp1_k),tau_1_nue_i_jm1_k),tau_1_nue_i_j_kp1),tau_1_nue_i_j_km1);
+  const double new_tau_0_anue_i_j_k = fmin(fmin(fmin(fmin(fmin(tau_0_anue_ip1_j_k,tau_0_anue_im1_j_k),tau_0_anue_i_jp1_k),tau_0_anue_i_jm1_k),tau_0_anue_i_j_kp1),tau_0_anue_i_j_km1);
+  const double new_tau_1_anue_i_j_k = fmin(fmin(fmin(fmin(fmin(tau_1_anue_ip1_j_k,tau_1_anue_im1_j_k),tau_1_anue_i_jp1_k),tau_1_anue_i_jm1_k),tau_1_anue_i_j_kp1),tau_1_anue_i_j_km1);
+  const double new_tau_0_nux_i_j_k  = fmin(fmin(fmin(fmin(fmin(tau_0_nux_ip1_j_k,tau_0_nux_im1_j_k),tau_0_nux_i_jp1_k),tau_0_nux_i_jm1_k),tau_0_nux_i_j_kp1),tau_0_nux_i_j_km1);
+  const double new_tau_1_nux_i_j_k  = fmin(fmin(fmin(fmin(fmin(tau_1_nux_ip1_j_k,tau_1_nux_im1_j_k),tau_1_nux_i_jp1_k),tau_1_nux_i_jm1_k),tau_1_nux_i_j_kp1),tau_1_nux_i_j_km1);
 
   // Step 9: Write results
   tau_i_j_k->nue[0]  = new_tau_0_nue_i_j_k;

--- a/GRHayL/Reconstruction/PPM/shock_detection_ftilde.c
+++ b/GRHayL/Reconstruction/PPM/shock_detection_ftilde.c
@@ -29,12 +29,12 @@ double ghl_shock_detection_ftilde(
   if (dP2 != 0.0) dP1_over_dP2 = dP1/dP2;
 
   const double q1 = (dP1_over_dP2 - params->ppm_flattening_omega1) * params->ppm_flattening_omega2;
-  const double q2 = fabs(dP1)/MIN(P[PLUS_1], P[MINUS1]);
+  const double q2 = fabs(dP1)/fmin(P[PLUS_1], P[MINUS1]);
 
   // this if statement is equivalent to the w_j variable in the original Colella and Woodward paper
   if (q2 > params->ppm_flattening_epsilon && q2*( (v_flux_dirn[MINUS1]) - (v_flux_dirn[PLUS_1]) ) > 0.0) {
     // inside a shock
-    return MIN(1.0, MAX(0.0, q1));
+    return fmin(1.0, fmax(0.0, q1));
   } else {
     // NOT inside a shock
     return 0.0;

--- a/GRHayL/Reconstruction/PPM/slope_limit.c
+++ b/GRHayL/Reconstruction/PPM/slope_limit.c
@@ -27,7 +27,7 @@ double ghl_slope_limit(
     //    If delta_m_U==0,then (0.0 < delta_m_U)==0, and (delta_m_U < 0.0)==0, so sign_delta_a_j=0
     const int sign_delta_m_U = (0.0 < delta_m_U) - (delta_m_U < 0.0);
     //Decide whether to use 2nd order derivative or first-order derivative, limiting slope.
-    return sign_delta_m_U*MIN(fabs(delta_m_U), SLOPE_LIMITER_COEFF*MIN(fabs(dUp1), fabs(dU)));
+    return sign_delta_m_U*fmin(fabs(delta_m_U), SLOPE_LIMITER_COEFF*fmin(fabs(dUp1), fabs(dU)));
   }
   return 0.0;
 }

--- a/GRHayL/Reconstruction/PPM/steepen_var.c
+++ b/GRHayL/Reconstruction/PPM/steepen_var.c
@@ -20,11 +20,11 @@ void ghl_steepen_var(
   const double d1rho_b     = rho[PLUS_1] - rho[MINUS1];
   const double d2rho_b_m1  = rho[PLUS_0] - 2.0*rho[MINUS1] + rho[MINUS2];
   const double d2rho_b_p1  = rho[PLUS_2] - 2.0*rho[PLUS_1] + rho[PLUS_0];
-  const double rho_b_min = MIN(rho[PLUS_1], rho[MINUS1]);
+  const double rho_b_min = fmin(rho[PLUS_1], rho[MINUS1]);
 
   // Gamma_eff = (partial P / partial rho0)_s /(P/rho0)
   const bool contact_discontinuity_check =
-                 Gamma_eff * params->ppm_shock_k0 * fabs(d1rho_b) * MIN(pressure[PLUS_1], pressure[MINUS1])
+                 Gamma_eff * params->ppm_shock_k0 * fabs(d1rho_b) * fmin(pressure[PLUS_1], pressure[MINUS1])
                  >= fabs(pressure[PLUS_1]-pressure[MINUS1])*rho_b_min;
   const bool second_deriv_check = d2rho_b_p1*d2rho_b_m1 <= 0.0;
   const bool relative_change_check = fabs(d1rho_b) >= params->ppm_shock_epsilon*rho_b_min;
@@ -38,7 +38,7 @@ void ghl_steepen_var(
     if (fabs(d1rho_b) > 0.0) {
       eta_tilde = -(1.0/6.0)*(d2rho_b_p1 - d2rho_b_m1)/d1rho_b;
     }
-    const double eta = MAX(0.0, MIN(params->ppm_shock_eta1*(eta_tilde - params->ppm_shock_eta2), 1.0));
+    const double eta = fmax(0.0, fmin(params->ppm_shock_eta1*(eta_tilde - params->ppm_shock_eta2), 1.0));
 
     // Next compute Urp1 and Ul for RHOB, using the MC prescription:
     // Ur_p1 = U_p1   - 0.5*slope_lim_dU_p1

--- a/GRHayL/Reconstruction/WENOZ/wenoz_reconstruction_right_left_faces.c
+++ b/GRHayL/Reconstruction/WENOZ/wenoz_reconstruction_right_left_faces.c
@@ -62,7 +62,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 static double mc(const double dm, const double dp, const double alpha) {
   const double dc = (dm * dp > 0.0) * 0.5 * (dm + dp);
   return copysign(
-      MIN(fabs(dc), alpha * MIN(fabs(dm), fabs(dp))), dc);
+      fmin(fabs(dc), alpha * fmin(fabs(dm), fabs(dp))), dc);
 }
 
 void ghl_wenoz_reconstruction_right_left_faces(

--- a/GRHayL/include/ghl.h
+++ b/GRHayL/include/ghl.h
@@ -6,14 +6,13 @@
 #include "ghl_io.h"
 #include "ghl_metric_helpers.h"
 
-#ifndef MIN
-#define MIN(A, B) (((A) < (B)) ? (A) : (B))
-#endif
-#ifndef MAX
-#define MAX(A, B) (((A) > (B)) ? (A) : (B))
-#endif
+#ifndef SQR
 #define SQR(x) ((x) * (x))
+#endif
+
+#ifndef ONE_OVER_SQRT_4PI
 #define ONE_OVER_SQRT_4PI 0.282094791773878143474039725780
+#endif
 
 #ifndef M_PI
 #define M_PI 3.141592653589793238462643383279502884L

--- a/GRHayL/include/ghl_nrpyleakage.h
+++ b/GRHayL/include/ghl_nrpyleakage.h
@@ -1,17 +1,6 @@
 #ifndef NRPYLEAKAGE_H_
 #define NRPYLEAKAGE_H_
 
-#ifdef MIN
-#undef MIN
-#endif
-
-#ifdef MAX
-#undef MAX
-#endif
-
-#define MAX(a,b) ( (a) > (b) ? (a) : (b) )
-#define MIN(a,b) ( (a) < (b) ? (a) : (b) )
-
 // "Primary" parameters
 #define NRPyLeakage_enable_beta_nue (1)
 #define NRPyLeakage_enable_beta_anue (1)


### PR DESCRIPTION
Removed all instances of `MIN`/`MAX` macros from C code, using C library's `fmin`/`fmax`or static inline `imin`/`imax` functions as needed.

Ran all unit tests locally and they passed.