### PR TITLE
GRHayLib.h: export ghl_imax and ghl_imin

### DIFF
--- a/implementations/GRHayLib/src/GRHayLib.h
+++ b/implementations/GRHayLib/src/GRHayLib.h
@@ -15,4 +15,12 @@
 extern ghl_eos_parameters *ghl_eos;
 extern ghl_parameters *ghl_params;
 
+static inline int ghl_imax(int a, int b) {
+  return a > b ? a : b; 
+}
+
+static inline int ghl_imin(int a, int b) {
+  return a < b ? a : b; 
+}
+
 #endif // GRHAYLIB_H_


### PR DESCRIPTION
This PR modifies `GRHayLib.h` to export static inlined functions `ghl_imax` and `ghl_imin` to replace the `MAX` and `MIN` macros used for integer comparisons in ET thorns.

These will be used by:
* `IllinoisGRMHD`
* `GRHayLHD`
* `NRPyLeakageET`
* `TOVola`