### PR TITLE
Renamed ghl_con2prim_method_t -> ghl_con2prim_id_t

### DIFF
--- a/GRHayL/Con2Prim/Hybrid/Font1D/hybrid_Font1D.c
+++ b/GRHayL/Con2Prim/Hybrid/Font1D/hybrid_Font1D.c
@@ -210,6 +210,6 @@ ghl_error_codes_t ghl_hybrid_Font1D(
   if(params->evolve_entropy)
     prims->entropy = ghl_hybrid_compute_entropy_function(eos, prims->rho, prims->press);
 
-  diagnostics->which_routine = Font1D;
+  diagnostics->which_routine = ghl_con2prim_id_Font1D;
   return ghl_success;
 }

--- a/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D.c
@@ -106,6 +106,6 @@ ghl_error_codes_t ghl_hybrid_Noble1D(
 
   /* Done! */
   diagnostics->n_iter = harm_aux.n_iter;
-  diagnostics->which_routine = Noble1D;
+  diagnostics->which_routine = ghl_con2prim_id_Noble1D;
   return ghl_success;
 }

--- a/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D_entropy.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D_entropy.c
@@ -144,6 +144,6 @@ ghl_error_codes_t ghl_hybrid_Noble1D_entropy(
 
   /* Done! */
   diagnostics->n_iter = harm_aux.n_iter;
-  diagnostics->which_routine = Noble1D_entropy;
+  diagnostics->which_routine = ghl_con2prim_id_Noble1D_entropy;
   return ghl_success;
 }

--- a/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D_entropy2.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D_entropy2.c
@@ -127,6 +127,6 @@ ghl_error_codes_t ghl_hybrid_Noble1D_entropy2(
 
   /* Done! */
   diagnostics->n_iter = harm_aux.n_iter;
-  diagnostics->which_routine = Noble1D_entropy2;
+  diagnostics->which_routine = ghl_con2prim_id_Noble1D_entropy2;
   return ghl_success;
 }

--- a/GRHayL/Con2Prim/Hybrid/Noble/Noble2D/hybrid_Noble2D.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/Noble2D/hybrid_Noble2D.c
@@ -105,6 +105,6 @@ ghl_error_codes_t ghl_hybrid_Noble2D(
 
   /* Done! */
   diagnostics->n_iter = harm_aux.n_iter;
-  diagnostics->which_routine = Noble2D;
+  diagnostics->which_routine = ghl_con2prim_id_Noble2D;
   return ghl_success;
 }

--- a/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D_energy.c
+++ b/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D_energy.c
@@ -70,7 +70,7 @@ ghl_error_codes_t ghl_hybrid_Palenzuela1D_energy(
       ghl_primitive_quantities *restrict prims,
       ghl_con2prim_diagnostics *restrict diagnostics) {
 
-  diagnostics->which_routine = Palenzuela1D;
+  diagnostics->which_routine = ghl_con2prim_id_Palenzuela1D;
   return ghl_hybrid_Palenzuela1D(compute_rho_P_eps_W_energy,
                                  params,
                                  eos,

--- a/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D_entropy.c
+++ b/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D_entropy.c
@@ -68,7 +68,7 @@ ghl_error_codes_t ghl_hybrid_Palenzuela1D_entropy(
       ghl_primitive_quantities *restrict prims,
       ghl_con2prim_diagnostics *restrict diagnostics) {
 
-  diagnostics->which_routine = Palenzuela1D_entropy;
+  diagnostics->which_routine = ghl_con2prim_id_Palenzuela1D_entropy;
   return ghl_hybrid_Palenzuela1D(compute_rho_P_eps_W_entropy,
                                  params,
                                  eos,

--- a/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_energy.c
+++ b/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_energy.c
@@ -155,7 +155,7 @@ ghl_error_codes_t ghl_tabulated_Newman1D_energy(
 
   // Step 2: Call the Newman routine that uses the energy to recover T
   const double tol_x = 1e-15;
-  diagnostics->which_routine = Newman1D;
+  diagnostics->which_routine = ghl_con2prim_id_Newman1D;
 
   ghl_error_codes_t error = ghl_newman_energy(params, eos, Ssq, BdotS, Bsq, SU, ADM_metric,
 				cons_undens, prims, tol_x, diagnostics);

--- a/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_entropy.c
+++ b/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_entropy.c
@@ -147,7 +147,7 @@ ghl_error_codes_t ghl_tabulated_Newman1D_entropy(
 
   // Step 2: Call the Newman routine that uses the entropy to recover T
   const double tol_x = 1e-15;
-  diagnostics->which_routine = Newman1D_entropy;
+  diagnostics->which_routine = ghl_con2prim_id_Newman1D_entropy;
 
   ghl_error_codes_t error = ghl_newman_entropy(params, eos, Ssq, BdotS, Bsq, SU, ADM_metric,
 				 cons_undens, prims, tol_x, diagnostics);

--- a/GRHayL/Con2Prim/Tabulated/Palenzuela1D/tabulated_Palenzuela1D_energy.c
+++ b/GRHayL/Con2Prim/Tabulated/Palenzuela1D/tabulated_Palenzuela1D_energy.c
@@ -77,7 +77,7 @@ ghl_error_codes_t ghl_tabulated_Palenzuela1D_energy(
       ghl_primitive_quantities *restrict prims,
       ghl_con2prim_diagnostics *restrict diagnostics) {
 
-  diagnostics->which_routine = Palenzuela1D;
+  diagnostics->which_routine = ghl_con2prim_id_Palenzuela1D;
   return ghl_tabulated_Palenzuela1D(compute_rho_P_eps_T_W_energy,
                                 params,
                                 eos,

--- a/GRHayL/Con2Prim/Tabulated/Palenzuela1D/tabulated_Palenzuela1D_entropy.c
+++ b/GRHayL/Con2Prim/Tabulated/Palenzuela1D/tabulated_Palenzuela1D_entropy.c
@@ -71,7 +71,7 @@ ghl_error_codes_t ghl_tabulated_Palenzuela1D_entropy(
       ghl_primitive_quantities *restrict prims,
       ghl_con2prim_diagnostics *restrict diagnostics) {
 
-  diagnostics->which_routine = Palenzuela1D_entropy;
+  diagnostics->which_routine = ghl_con2prim_id_Palenzuela1D_entropy;
   return ghl_tabulated_Palenzuela1D(
                compute_rho_P_eps_T_W_entropy,
                params,

--- a/GRHayL/Con2Prim/con2prim_multi_method.c
+++ b/GRHayL/Con2Prim/con2prim_multi_method.c
@@ -7,7 +7,7 @@
 */
 
 ghl_error_codes_t ghl_con2prim_hybrid_select_method(
-      const ghl_con2prim_method_t c2p_key,
+      const ghl_con2prim_id_t c2p_key,
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
       const ghl_metric_quantities *restrict ADM_metric,
@@ -18,22 +18,22 @@ ghl_error_codes_t ghl_con2prim_hybrid_select_method(
 
   switch(c2p_key) {
     // Noble routines (see https://arxiv.org/pdf/astro-ph/0512420.pdf)
-    case Noble2D:
+    case ghl_con2prim_id_Noble2D:
       return ghl_hybrid_Noble2D(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
-    case Noble1D:
+    case ghl_con2prim_id_Noble1D:
       return ghl_hybrid_Noble1D(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics); 
     // Font routine (see https://arxiv.org/abs/gr-qc/9811015)
-    case Font1D:
+    case ghl_con2prim_id_Font1D:
       return ghl_hybrid_Font1D(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
     // Palenzuela1D routine (see https://arxiv.org/pdf/1712.07538.pdf)
-    case Palenzuela1D:
+    case ghl_con2prim_id_Palenzuela1D:
       return ghl_hybrid_Palenzuela1D_energy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
     // Entropy routines (see https://arxiv.org/abs/2208.14487)
-    case Noble1D_entropy:
+    case ghl_con2prim_id_Noble1D_entropy:
       return ghl_hybrid_Noble1D_entropy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics); 
     //case Noble1D_entropy2:
     //  return ghl_hybrid_Noble1D_entropy2(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics); 
-    case Palenzuela1D_entropy:
+    case ghl_con2prim_id_Palenzuela1D_entropy:
       return ghl_hybrid_Palenzuela1D_entropy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
     default:
       return ghl_error_invalid_c2p_key;
@@ -47,7 +47,7 @@ ghl_error_codes_t ghl_con2prim_hybrid_select_method(
 */
 
 ghl_error_codes_t ghl_con2prim_tabulated_select_method(
-      const ghl_con2prim_method_t c2p_key,
+      const ghl_con2prim_id_t c2p_key,
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
       const ghl_metric_quantities *restrict ADM_metric,
@@ -61,15 +61,15 @@ ghl_error_codes_t ghl_con2prim_tabulated_select_method(
 #else
   switch(c2p_key) {
     // Palenzuela1D routine (see https://arxiv.org/pdf/1712.07538.pdf)
-    case Palenzuela1D:
+    case ghl_con2prim_id_Palenzuela1D:
       return ghl_tabulated_Palenzuela1D_energy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
     // Newman 1D routine (see https://escholarship.org/uc/item/0s53f84b)
-    case Newman1D:
+    case ghl_con2prim_id_Newman1D:
       return ghl_tabulated_Newman1D_energy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
     // Entropy routines (see https://arxiv.org/abs/2208.14487)
-    case Palenzuela1D_entropy:
+    case ghl_con2prim_id_Palenzuela1D_entropy:
       return ghl_tabulated_Palenzuela1D_entropy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
-    case Newman1D_entropy:
+    case ghl_con2prim_id_Newman1D_entropy:
       return ghl_tabulated_Newman1D_entropy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
     default:
       return ghl_error_invalid_c2p_key;
@@ -100,7 +100,7 @@ ghl_error_codes_t ghl_con2prim_hybrid_multi_method(
 
   ghl_error_codes_t error = ghl_con2prim_hybrid_select_method(params->main_routine, params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
 
-  if(error && params->backup_routine[0] != None) {
+  if(error && params->backup_routine[0] != ghl_con2prim_id_None) {
     // Backup 1 triggered
     diagnostics->backup[0] = true;
     // Reset guesses
@@ -108,7 +108,7 @@ ghl_error_codes_t ghl_con2prim_hybrid_multi_method(
     // Backup routine #1
     error = ghl_con2prim_hybrid_select_method(params->backup_routine[0], params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
 
-    if(error && params->backup_routine[1] != None) {
+    if(error && params->backup_routine[1] != ghl_con2prim_id_None) {
       // Backup 2 triggered
       diagnostics->backup[1] = true;
       // Reset guesses
@@ -116,7 +116,7 @@ ghl_error_codes_t ghl_con2prim_hybrid_multi_method(
       // Backup routine #2
       error = ghl_con2prim_hybrid_select_method(params->backup_routine[1], params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
 
-      if(error && params->backup_routine[2] != None) {
+      if(error && params->backup_routine[2] != ghl_con2prim_id_None) {
         // Backup 3 triggered
         diagnostics->backup[2] = true;
         // Reset guesses
@@ -155,7 +155,7 @@ ghl_error_codes_t ghl_con2prim_tabulated_multi_method(
 
   ghl_error_codes_t error = ghl_con2prim_tabulated_select_method(params->main_routine, params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
 
-  if(error && params->backup_routine[0] != None) {
+  if(error && params->backup_routine[0] != ghl_con2prim_id_None) {
     // Backup 1 triggered
     diagnostics->backup[0] = true;
     // Reset guesses
@@ -163,7 +163,7 @@ ghl_error_codes_t ghl_con2prim_tabulated_multi_method(
     // Backup routine #1
     error = ghl_con2prim_tabulated_select_method(params->backup_routine[0], params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
 
-    if(error && params->backup_routine[1] != None) {
+    if(error && params->backup_routine[1] != ghl_con2prim_id_None) {
       // Backup 2 triggered
       diagnostics->backup[1] = true;
       // Reset guesses
@@ -171,7 +171,7 @@ ghl_error_codes_t ghl_con2prim_tabulated_multi_method(
       // Backup routine #2
       error = ghl_con2prim_tabulated_select_method(params->backup_routine[1], params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
 
-      if(error && params->backup_routine[2] != None) {
+      if(error && params->backup_routine[2] != ghl_con2prim_id_None) {
         // Backup 3 triggered
         diagnostics->backup[2] = true;
         // Reset guesses

--- a/GRHayL/Con2Prim/con2prim_multi_method.c
+++ b/GRHayL/Con2Prim/con2prim_multi_method.c
@@ -31,8 +31,6 @@ ghl_error_codes_t ghl_con2prim_hybrid_select_method(
     // Entropy routines (see https://arxiv.org/abs/2208.14487)
     case ghl_con2prim_id_Noble1D_entropy:
       return ghl_hybrid_Noble1D_entropy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics); 
-    //case Noble1D_entropy2:
-    //  return ghl_hybrid_Noble1D_entropy2(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics); 
     case ghl_con2prim_id_Palenzuela1D_entropy:
       return ghl_hybrid_Palenzuela1D_entropy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
     default:

--- a/GRHayL/Con2Prim/get_con2prim_routine_name.c
+++ b/GRHayL/Con2Prim/get_con2prim_routine_name.c
@@ -6,34 +6,34 @@
  *
  * @details
  * This function returns the name of a conservative-to-primitive solver method
- * given a @ref ghl_con2prim_method_t key. If key matches nothing in the enum,
+ * given a @ref ghl_con2prim_id_t key. If key matches nothing in the enum,
  * then the function returns NULL.
  *
- * @param[in] key key from @ref ghl_con2prim_method_t selecting a method
+ * @param[in] key key from @ref ghl_con2prim_id_t selecting a method
  *
  * @returns the name of the conservative-to-primitive solver method
  */
-const char *ghl_get_con2prim_routine_name(const ghl_con2prim_method_t key) {
+const char *ghl_get_con2prim_routine_name(const ghl_con2prim_id_t key) {
   switch(key) {
-    case None:
+    case ghl_con2prim_id_None:
       return "None";
-    case Noble2D:
+    case ghl_con2prim_id_Noble2D:
       return "Noble2D";
-    case Noble1D:
+    case ghl_con2prim_id_Noble1D:
       return "Noble1D";
-    case Noble1D_entropy:
+    case ghl_con2prim_id_Noble1D_entropy:
       return "Noble1D_entropy";
-    case Noble1D_entropy2:
+    case ghl_con2prim_id_Noble1D_entropy2:
       return "Noble1D_entropy2";
-    case Font1D:
+    case ghl_con2prim_id_Font1D:
       return "Font1D";
-    case Palenzuela1D:
+    case ghl_con2prim_id_Palenzuela1D:
       return "Palenzuela1D";
-    case Palenzuela1D_entropy:
+    case ghl_con2prim_id_Palenzuela1D_entropy:
       return "Palenzuela1D_entropy";
-    case Newman1D:
+    case ghl_con2prim_id_Newman1D:
       return "Newman1D";
-    case Newman1D_entropy:
+    case ghl_con2prim_id_Newman1D_entropy:
       return "Newman1D_entropy";
     default:
       return NULL;

--- a/GRHayL/Con2Prim/initialize_diagnostics.c
+++ b/GRHayL/Con2Prim/initialize_diagnostics.c
@@ -15,5 +15,5 @@ void ghl_initialize_diagnostics(ghl_con2prim_diagnostics *restrict diagnostics) 
   diagnostics->backup[0]     = false;
   diagnostics->backup[1]     = false;
   diagnostics->backup[2]     = false;
-  diagnostics->which_routine = None;
+  diagnostics->which_routine = ghl_con2prim_id_None;
 }

--- a/GRHayL/GRHayL_Core/initialize_params.c
+++ b/GRHayL/GRHayL_Core/initialize_params.c
@@ -29,11 +29,11 @@
  * which come from the original Colella and Woodward [paper](https://www.sciencedirect.com/science/article/abs/pii/0021999184901438?via%3Dihub).
  *
  * @param[in] main_routine selects the primary conservative-to-primitive routine for @ref ghl_con2prim_multi_method
- *                                   function; options are limited to @ref ghl_con2prim_method_t
+ *                                   function; options are limited to @ref ghl_con2prim_id_t
  *
  * @param[in] backup_routine selects backup conservative-to-primitive routines for @ref ghl_con2prim_multi_method
  *                                   function; up to 3 backups can be selected, with no backup being -1; options are
- *                                   limited to @ref ghl_con2prim_method_t
+ *                                   limited to @ref ghl_con2prim_id_t
  *
  * @param[in] evolve_entropy whether entropy should be evolved (True) or not (False)
  *
@@ -54,8 +54,8 @@
  *
  */
 void ghl_initialize_params(
-      const ghl_con2prim_method_t main_routine,
-      const ghl_con2prim_method_t backup_routine[3],
+      const ghl_con2prim_id_t main_routine,
+      const ghl_con2prim_id_t backup_routine[3],
       const bool evolve_entropy,
       const bool evolve_temp,
       const bool calc_prim_guess,

--- a/GRHayL/include/ghl.h
+++ b/GRHayL/include/ghl.h
@@ -70,22 +70,22 @@ typedef enum {
 } ghl_error_codes_t;
 
 typedef enum {
-  None = -1,
-  Noble2D,
-  Noble1D,
-  Noble1D_entropy,
-  Noble1D_entropy2,
-  Font1D,
-  Palenzuela1D,
-  Palenzuela1D_entropy,
-  Newman1D,
-  Newman1D_entropy
-} ghl_con2prim_method_t;
+  ghl_con2prim_id_None = -1,
+  ghl_con2prim_id_Noble2D,
+  ghl_con2prim_id_Noble1D,
+  ghl_con2prim_id_Noble1D_entropy,
+  ghl_con2prim_id_Noble1D_entropy2,
+  ghl_con2prim_id_Font1D,
+  ghl_con2prim_id_Palenzuela1D,
+  ghl_con2prim_id_Palenzuela1D_entropy,
+  ghl_con2prim_id_Newman1D,
+  ghl_con2prim_id_Newman1D_entropy,
+} ghl_con2prim_id_t;
 
 typedef enum {
   ghl_eos_simple,
   ghl_eos_hybrid,
-  ghl_eos_tabulated
+  ghl_eos_tabulated,
 } ghl_eos_t;
 
 typedef enum {
@@ -100,7 +100,7 @@ typedef enum {
  * Documentation : https://github.com/GRHayL/GRHayL/wiki/ghl_parameters
 */
 typedef struct ghl_parameters {
-  ghl_con2prim_method_t main_routine, backup_routine[3];
+  ghl_con2prim_id_t main_routine, backup_routine[3];
   bool evolve_entropy;
   bool evolve_temp;
   bool calc_prim_guess;
@@ -291,7 +291,7 @@ typedef struct ghl_eos_parameters {
 
 } ghl_eos_parameters;
 
-const char *ghl_get_con2prim_routine_name(const ghl_con2prim_method_t key);
+const char *ghl_get_con2prim_routine_name(const ghl_con2prim_id_t key);
 
 void ghl_initialize_eos_functions(
     const ghl_eos_t eos_type);
@@ -368,8 +368,8 @@ ghl_error_codes_t ghl_initialize_tabulated_eos_functions_and_params(
 
 //---- Basic struct packing/unpacking functions ----
 void ghl_initialize_params(
-      const ghl_con2prim_method_t main_routine,
-      const ghl_con2prim_method_t backup_routine[3],
+      const ghl_con2prim_id_t main_routine,
+      const ghl_con2prim_id_t backup_routine[3],
       const bool evolve_entropy,
       const bool evolve_temp,
       const bool calc_prim_guess,

--- a/GRHayL/include/ghl_con2prim.h
+++ b/GRHayL/include/ghl_con2prim.h
@@ -23,7 +23,7 @@ typedef struct ghl_con2prim_diagnostics {
   /** Whether a speed limiter was triggered (true) or not (false) */
   bool speed_limited;
   /** The Con2Prim routine which successfully found the primitive variables */
-  ghl_con2prim_method_t which_routine;
+  ghl_con2prim_id_t which_routine;
   /** Whether a given backup routine was used (true) or not (false) */
   bool backup[3];
   /** Number of iterations required to find the solution */
@@ -104,7 +104,7 @@ ghl_error_codes_t ghl_con2prim_tabulated_multi_method(
       ghl_con2prim_diagnostics *restrict diagnostics);
 
 ghl_error_codes_t ghl_con2prim_hybrid_select_method(
-      const ghl_con2prim_method_t c2p_key,
+      const ghl_con2prim_id_t c2p_key,
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
       const ghl_metric_quantities *restrict ADM_metric,
@@ -114,7 +114,7 @@ ghl_error_codes_t ghl_con2prim_hybrid_select_method(
       ghl_con2prim_diagnostics *restrict diagnostics );
 
 ghl_error_codes_t ghl_con2prim_tabulated_select_method(
-      const ghl_con2prim_method_t c2p_key,
+      const ghl_con2prim_id_t c2p_key,
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
       const ghl_metric_quantities *restrict ADM_metric,

--- a/Unit_Tests/data_gen/unit_test_data_ET_Legacy_conservs.c
+++ b/Unit_Tests/data_gen/unit_test_data_ET_Legacy_conservs.c
@@ -19,7 +19,8 @@ int main(int argc, char **argv) {
   double poison = 1e200;
   // This section sets up the initial parameters that would normally
   // be provided by the simulation.
-  int backup_routine[3] = {None,None,None};
+  const ghl_con2prim_id_t None = ghl_con2prim_id_None;
+  ghl_con2prim_id_t backup_routine[3] = {None, None, None};
   bool calc_prims_guess = true;
   double Psi6threshold = 1e100; //Taken from magnetizedTOV.par
   double W_max = 10.0; //IGM default
@@ -39,8 +40,8 @@ int main(int argc, char **argv) {
   // a simulation.
   ghl_parameters params;
   ghl_initialize_params(
-        Noble2D, backup_routine, evolve_entropy, evolve_temperature, calc_prims_guess,
-        Psi6threshold, W_max, Lorenz_damping_factor, &params);
+        ghl_con2prim_id_Noble2D, backup_routine, evolve_entropy, evolve_temperature,
+        calc_prims_guess, Psi6threshold, W_max, Lorenz_damping_factor, &params);
 
   ghl_eos_parameters eos = { 0 };
   ghl_initialize_hybrid_eos_functions_and_params(

--- a/Unit_Tests/data_gen/unit_test_data_ET_Legacy_primitives.c
+++ b/Unit_Tests/data_gen/unit_test_data_ET_Legacy_primitives.c
@@ -20,7 +20,8 @@ int main(int argc, char **argv) {
   double poison = 1e200;
   // This section sets up the initial parameters that would normally
   // be provided by the simulation.
-  int backup_routine[3] = {None,None,None};
+  const ghl_con2prim_id_t None = ghl_con2prim_id_None;
+  ghl_con2prim_id_t backup_routine[3] = {None, None, None};
   bool calc_prims_guess = true;
   double Psi6threshold = 1e100; //Taken from magnetizedTOV.par
   const bool evolve_entropy = false;
@@ -40,8 +41,8 @@ int main(int argc, char **argv) {
   // a simulation.
   ghl_parameters params;
   ghl_initialize_params(
-        Noble2D, backup_routine, evolve_entropy, evolve_temperature, calc_prims_guess,
-        Psi6threshold, W_max, Lorenz_damping_factor, &params);
+        ghl_con2prim_id_Noble2D, backup_routine, evolve_entropy, evolve_temperature,
+        calc_prims_guess, Psi6threshold, W_max, Lorenz_damping_factor, &params);
 
   ghl_eos_parameters eos = { 0 };
   ghl_initialize_hybrid_eos_functions_and_params(

--- a/Unit_Tests/data_gen/unit_test_data_con2prim_multi_method_hybrid.c
+++ b/Unit_Tests/data_gen/unit_test_data_con2prim_multi_method_hybrid.c
@@ -25,22 +25,22 @@ int main(int argc, char **argv) {
   int methods[num_routines];
   bool uses_entropy[num_routines];
 
-  methods[0] = Font1D;
+  methods[0] = ghl_con2prim_id_Font1D;
   uses_entropy[0] = false;
-  methods[1] = Palenzuela1D;
+  methods[1] = ghl_con2prim_id_Palenzuela1D;
   uses_entropy[1] = false;
-  methods[2] = Noble1D_entropy;
+  methods[2] = ghl_con2prim_id_Noble1D_entropy;
   uses_entropy[2] = true;
-  methods[3] = Palenzuela1D_entropy;
+  methods[3] = ghl_con2prim_id_Palenzuela1D_entropy;
   uses_entropy[3] = true;
-  methods[4] = Noble1D;
+  methods[4] = ghl_con2prim_id_Noble1D;
   uses_entropy[4] = false;
   //methods[5] = Noble1D_entropy2;
   //uses_entropy[5] = true;
 
   // To ensure the behavior remains the same for functions after Con2Prim,
   // we explicitly set a routine to always be last.
-  methods[num_routines-1] = Noble2D;
+  methods[num_routines-1] = ghl_con2prim_id_Noble2D;
   uses_entropy[num_routines-1] = false;
 
   double dummy2, dummy3;
@@ -48,8 +48,9 @@ int main(int argc, char **argv) {
 
   // This section sets up the initial parameters that would normally
   // be provided by the simulation.
-  const int main_routine = None;
-  const int backup_routine[3] = {None,None,None};
+  const ghl_con2prim_id_t None = ghl_con2prim_id_None;
+  const ghl_con2prim_id_t main_routine = None;
+  const ghl_con2prim_id_t backup_routine[3] = {None, None, None};
   const bool evolve_entropy = true;
   const bool evolve_temperature = false;
   const bool calc_prims_guess = true;

--- a/Unit_Tests/data_gen/unit_test_data_con2prim_multi_method_hybrid.c
+++ b/Unit_Tests/data_gen/unit_test_data_con2prim_multi_method_hybrid.c
@@ -35,8 +35,6 @@ int main(int argc, char **argv) {
   uses_entropy[3] = true;
   methods[4] = ghl_con2prim_id_Noble1D;
   uses_entropy[4] = false;
-  //methods[5] = Noble1D_entropy2;
-  //uses_entropy[5] = true;
 
   // To ensure the behavior remains the same for functions after Con2Prim,
   // we explicitly set a routine to always be last.

--- a/Unit_Tests/unit_test_ET_Legacy_conservs.c
+++ b/Unit_Tests/unit_test_ET_Legacy_conservs.c
@@ -21,7 +21,8 @@ int main(int argc, char **argv) {
   const double poison = 1e300;
   // This section sets up the initial parameters that would normally
   // be provided by the simulation.
-  const int backup_routine[3] = {None,None,None};
+  const ghl_con2prim_id_t None = ghl_con2prim_id_None;
+  const ghl_con2prim_id_t backup_routine[3] = {None, None, None};
   const bool calc_prims_guess = true;
   const double Psi6threshold = 1e100; //Taken from magnetizedTOV.par
   const double W_max = 10.0; //IGM default
@@ -41,8 +42,8 @@ int main(int argc, char **argv) {
   // a simulation.
   ghl_parameters params;
   ghl_initialize_params(
-        Noble2D, backup_routine, evolve_entropy, evolve_temperature, calc_prims_guess,
-        Psi6threshold, W_max, Lorenz_damping_factor, &params);
+        ghl_con2prim_id_Noble2D, backup_routine, evolve_entropy, evolve_temperature,
+        calc_prims_guess, Psi6threshold, W_max, Lorenz_damping_factor, &params);
 
   ghl_eos_parameters eos = { 0 };
   ghl_initialize_hybrid_eos_functions_and_params(

--- a/Unit_Tests/unit_test_ET_Legacy_primitives.c
+++ b/Unit_Tests/unit_test_ET_Legacy_primitives.c
@@ -19,7 +19,8 @@ int main(int argc, char **argv) {
   const double poison = 1e300;
   // This section sets up the initial parameters that would normally
   // be provided by the simulation.
-  const int backup_routine[3] = {Font1D,None,None};
+  const ghl_con2prim_id_t None = ghl_con2prim_id_None;
+  const ghl_con2prim_id_t backup_routine[3] = {ghl_con2prim_id_Font1D, None, None};
   const bool calc_prims_guess = true;
   const double Psi6threshold = 1e100; //Taken from magnetizedTOV.par
   const double W_max = 10.0; //IGM default
@@ -39,8 +40,8 @@ int main(int argc, char **argv) {
   // a simulation.
   ghl_parameters params;
   ghl_initialize_params(
-        Noble2D, backup_routine, evolve_entropy, evolve_temperature, calc_prims_guess,
-        Psi6threshold, W_max, Lorenz_damping_factor, &params);
+        ghl_con2prim_id_Noble2D, backup_routine, evolve_entropy, evolve_temperature,
+        calc_prims_guess, Psi6threshold, W_max, Lorenz_damping_factor, &params);
 
   ghl_eos_parameters eos = { 0 };
   ghl_initialize_hybrid_eos_functions_and_params(

--- a/Unit_Tests/unit_test_ET_Legacy_reconstruction.c
+++ b/Unit_Tests/unit_test_ET_Legacy_reconstruction.c
@@ -6,13 +6,13 @@ static double eos_Gamma_eff(const ghl_eos_parameters *restrict eos, const double
 int main(int argc, char **argv) {
   const double poison = 1e300;
 
-  const int backups[3] = {None, None, None};
+  const ghl_con2prim_id_t None = ghl_con2prim_id_None;
+  const ghl_con2prim_id_t backups[3] = {None, None, None};
 
   // None of these parameters actually matter. We are only using
   // the default values set in the initialize function for PPM.
   ghl_parameters params;
-  ghl_initialize_params(
-        None, backups, false, false, true, 0, 10, 0.0, &params);
+  ghl_initialize_params(None, backups, false, false, true, 0, 10, 0.0, &params);
 
   const int neos = 1;
   const double rho_ppoly_in[1] = {0.0};

--- a/Unit_Tests/unit_test_apply_conservative_limits.c
+++ b/Unit_Tests/unit_test_apply_conservative_limits.c
@@ -13,7 +13,8 @@ int main(int argc, char **argv) {
 
   // This section sets up the initial parameters that would normally
   // be provided by the simulation.
-  const int backup_routine[3] = {None,None,None};
+  const ghl_con2prim_id_t None = ghl_con2prim_id_None;
+  const ghl_con2prim_id_t backup_routine[3] = {None, None, None};
   const bool evolve_entropy = false;
   const bool evolve_temperature = false;
   const bool calc_prims_guess = true;

--- a/Unit_Tests/unit_test_code_error.c
+++ b/Unit_Tests/unit_test_code_error.c
@@ -45,7 +45,8 @@ int main(int argc, char **argv) {
 
   ghl_error_codes_t error = ghl_success;
 
-  int backup_routine[3] = {None,None,None};
+  const ghl_con2prim_id_t None = ghl_con2prim_id_None;
+  const ghl_con2prim_id_t backup_routine[3] = {None, None, None};
   bool evolve_entropy = false;
   bool evolve_temperature = false;
   bool calc_prims_guess = true;

--- a/Unit_Tests/unit_test_compute_conservs_and_Tmunu.c
+++ b/Unit_Tests/unit_test_compute_conservs_and_Tmunu.c
@@ -13,7 +13,8 @@ int main(int argc, char **argv) {
 
   // This section sets up the initial parameters that would normally
   // be provided by the simulation.
-  const int backup_routine[3] = {None,None,None};
+  const ghl_con2prim_id_t None = ghl_con2prim_id_None;
+  const ghl_con2prim_id_t backup_routine[3] = {None, None, None};
   const bool evolve_entropy = true;
   const bool evolve_temperature = false;
   const bool calc_prims_guess = true;

--- a/Unit_Tests/unit_test_con2prim_debug.c
+++ b/Unit_Tests/unit_test_con2prim_debug.c
@@ -75,8 +75,9 @@ int main(int argc, char **argv) {
 
   // This section sets up the initial parameters that would normally
   // be provided by the simulation.
-  const ghl_con2prim_method_t main_routine       = Newman1D;
-  const ghl_con2prim_method_t backup_routines[3] = {None,None,None};
+  const ghl_con2prim_id_t None               = ghl_con2prim_id_None;
+  const ghl_con2prim_id_t main_routine       = ghl_con2prim_id_Newman1D;
+  const ghl_con2prim_id_t backup_routines[3] = {None, None, None};
   const bool calc_prims_guess                = false;
   const bool evolve_entropy                  = false;
   const bool evolve_temperature              = true;

--- a/Unit_Tests/unit_test_con2prim_multi_method_hybrid.c
+++ b/Unit_Tests/unit_test_con2prim_multi_method_hybrid.c
@@ -6,19 +6,19 @@ int main(int argc, char **argv) {
   int methods[num_methods];
   bool uses_entropy[num_methods];
 
-  methods[0] = Font1D;
+  methods[0] = ghl_con2prim_id_Font1D;
   uses_entropy[0] = false;
-  methods[1] = Palenzuela1D;
+  methods[1] = ghl_con2prim_id_Palenzuela1D;
   uses_entropy[1] = false;
-  methods[2] = Noble1D_entropy;
+  methods[2] = ghl_con2prim_id_Noble1D_entropy;
   uses_entropy[2] = true;
-  methods[3] = Palenzuela1D_entropy;
+  methods[3] = ghl_con2prim_id_Palenzuela1D_entropy;
   uses_entropy[3] = true;
-  methods[4] = Noble1D;
+  methods[4] = ghl_con2prim_id_Noble1D;
   uses_entropy[4] = false;
   //methods[5] = Noble1D_entropy2;
   //uses_entropy[5] = true;
-  methods[num_methods-1] = Noble2D;
+  methods[num_methods-1] = ghl_con2prim_id_Noble2D;
   uses_entropy[num_methods-1] = false;
 
   FILE* infile = fopen_with_check("metric_Bfield_initial_data.bin","rb");
@@ -32,8 +32,9 @@ int main(int argc, char **argv) {
 
   // This section sets up the initial parameters that would normally
   // be provided by the simulation.
-  const int main_routine = None;
-  const int backup_routine[3] = {None,None,None};
+  const ghl_con2prim_id_t None = ghl_con2prim_id_None;
+  const ghl_con2prim_id_t main_routine = None;
+  const ghl_con2prim_id_t backup_routine[3] = {None, None, None};
   const bool evolve_entropy = false;
   const bool evolve_temperature = false;
   const bool calc_prims_guess = true;
@@ -223,7 +224,9 @@ int main(int argc, char **argv) {
       // or not can change by simply using a different compiler. The following bypasses errors associated with
       // different return values and doesn't skip the comparison of returned values for non-zero values.
       if(check != c2p_check[i]) {
-        if(methods[method] != Noble1D && methods[method] != Noble1D_entropy && methods[method] != Noble2D) {
+        if(methods[method] != ghl_con2prim_id_Noble1D &&
+           methods[method] != ghl_con2prim_id_Noble1D_entropy &&
+           methods[method] != ghl_con2prim_id_Noble2D) {
           ghl_error("unit_test_hybrid_con2prim has different return value for %.30s method: new %d vs old %d\n", ghl_get_con2prim_routine_name(methods[method]), check, c2p_check[i]);
         } else if(check != ghl_error_neg_pressure && c2p_check[i] != 6) {
           ghl_error("unit_test_hybrid_con2prim has different return value for %.30s method: new %d vs old %d\n", ghl_get_con2prim_routine_name(methods[method]), check, c2p_check[i]);
@@ -252,7 +255,7 @@ int main(int argc, char **argv) {
 
       double pressure_cutoff = 1.0e-30; // Set defaults and change them for Noble2D
       double eps_cutoff = 1.0e-30;
-      if(params.main_routine != Font1D) {
+      if(params.main_routine != ghl_con2prim_id_Font1D) {
         // Some routines have problems with losing accuracy in pressure, especially with small values
         // We relax the requirements because simply using a different compiler can cause the
         // test to fail for some inputs.

--- a/Unit_Tests/unit_test_con2prim_multi_method_hybrid.c
+++ b/Unit_Tests/unit_test_con2prim_multi_method_hybrid.c
@@ -16,8 +16,6 @@ int main(int argc, char **argv) {
   uses_entropy[3] = true;
   methods[4] = ghl_con2prim_id_Noble1D;
   uses_entropy[4] = false;
-  //methods[5] = Noble1D_entropy2;
-  //uses_entropy[5] = true;
   methods[num_methods-1] = ghl_con2prim_id_Noble2D;
   uses_entropy[num_methods-1] = false;
 

--- a/Unit_Tests/unit_test_con2prim_tabulated.c
+++ b/Unit_Tests/unit_test_con2prim_tabulated.c
@@ -336,7 +336,6 @@ int main(int argc, char **argv) {
     params.main_routine = ghl_con2prim_id_Newman1D_entropy; run_unit_test(&params, &eos);
     // The routines below fail for high temperatures/magnetizations,
     // respectively. We use the standard Palenzuela routine as a backup.
-    // params.backup_routine[0] = Palenzuela1D;
     params.backup_routine[0] = ghl_con2prim_id_Palenzuela1D;
     params.main_routine = ghl_con2prim_id_Newman1D;             run_unit_test(&params, &eos);
     params.main_routine = ghl_con2prim_id_Palenzuela1D_entropy; run_unit_test(&params, &eos);

--- a/Unit_Tests/unit_test_con2prim_tabulated.c
+++ b/Unit_Tests/unit_test_con2prim_tabulated.c
@@ -1,27 +1,11 @@
 #include <string.h>
 #include "ghl_unit_tests.h"
 
-const char *get_routine_string(const ghl_con2prim_method_t key) {
-  switch(key) {
-    case Palenzuela1D:
-      return "Palenzuela1D";
-    case Palenzuela1D_entropy:
-      return "Palenzuela1D_entropy";
-    case Newman1D:
-      return "Newman1D";
-    case Newman1D_entropy:
-      return "Newman1D_entropy";
-    default:
-      ghl_error("Unsupported key %d\n", key);
-      return NULL;
-  }
-}
-
 void generate_test_data(
     const ghl_parameters *restrict params,
     const ghl_eos_parameters *restrict eos ) {
 
-  const char *routine = get_routine_string(params->main_routine);
+  const char *routine = ghl_get_con2prim_routine_name(params->main_routine);
   ghl_info("Beginning data generation for %s\n", routine);
 
   const int npoints = 32; // must be > 1
@@ -204,7 +188,7 @@ void run_unit_test(
     const ghl_parameters *restrict params,
     const ghl_eos_parameters *restrict eos ) {
 
-  const char *routine = get_routine_string(params->main_routine);
+  const char *routine = ghl_get_con2prim_routine_name(params->main_routine);
   ghl_info("Beginning unit test for %s\n", routine);
 
   for(int vars_key=0;vars_key<=1;vars_key++) {
@@ -301,8 +285,9 @@ int main(int argc, char **argv) {
 
   // This section sets up the initial parameters that would normally
   // be provided by the simulation.
-  const ghl_con2prim_method_t main_routine       = None;
-  const ghl_con2prim_method_t backup_routines[3] = {None,None,None};
+  const ghl_con2prim_id_t None               = ghl_con2prim_id_None;
+  const ghl_con2prim_id_t main_routine       = None;
+  const ghl_con2prim_id_t backup_routines[3] = {None,None,None};
   const bool calc_prims_guess                = true;
   const bool evolve_entropy                  = false;
   const bool evolve_temperature              = true;
@@ -347,24 +332,24 @@ int main(int argc, char **argv) {
   eos.root_finding_precision=1e-10;
 
   if( test_key ) {
-    params.main_routine = Palenzuela1D;     run_unit_test(&params, &eos);
-    params.main_routine = Newman1D_entropy; run_unit_test(&params, &eos);
+    params.main_routine = ghl_con2prim_id_Palenzuela1D;     run_unit_test(&params, &eos);
+    params.main_routine = ghl_con2prim_id_Newman1D_entropy; run_unit_test(&params, &eos);
     // The routines below fail for high temperatures/magnetizations,
     // respectively. We use the standard Palenzuela routine as a backup.
     // params.backup_routine[0] = Palenzuela1D;
-    params.backup_routine[0] = Palenzuela1D;
-    params.main_routine = Newman1D;             run_unit_test(&params, &eos);
-    params.main_routine = Palenzuela1D_entropy; run_unit_test(&params, &eos);
+    params.backup_routine[0] = ghl_con2prim_id_Palenzuela1D;
+    params.main_routine = ghl_con2prim_id_Newman1D;             run_unit_test(&params, &eos);
+    params.main_routine = ghl_con2prim_id_Palenzuela1D_entropy; run_unit_test(&params, &eos);
     ghl_info("All tests succeeded\n");
   }
   else {
-    params.main_routine = Palenzuela1D;     generate_test_data(&params, &eos);
-    params.main_routine = Newman1D_entropy; generate_test_data(&params, &eos);
+    params.main_routine = ghl_con2prim_id_Palenzuela1D;     generate_test_data(&params, &eos);
+    params.main_routine = ghl_con2prim_id_Newman1D_entropy; generate_test_data(&params, &eos);
     // The routines below fail for high temperatures/magnetizations,
     // respectively. We use the standard Palenzuela routine as a backup.
-    params.backup_routine[0] = Palenzuela1D;
-    params.main_routine = Newman1D;             generate_test_data(&params, &eos);
-    params.main_routine = Palenzuela1D_entropy; generate_test_data(&params, &eos);
+    params.backup_routine[0] = ghl_con2prim_id_Palenzuela1D;
+    params.main_routine = ghl_con2prim_id_Newman1D;             generate_test_data(&params, &eos);
+    params.main_routine = ghl_con2prim_id_Palenzuela1D_entropy; generate_test_data(&params, &eos);
   }
 
   ghl_tabulated_free_memory(&eos);

--- a/Unit_Tests/unit_test_enforce_primitive_limits_and_compute_u0.c
+++ b/Unit_Tests/unit_test_enforce_primitive_limits_and_compute_u0.c
@@ -13,7 +13,8 @@ int main(int argc, char **argv) {
 
   // This section sets up the initial parameters that would normally
   // be provided by the simulation.
-  const int backup_routine[3] = {None,None,None};
+  const ghl_con2prim_id_t None = ghl_con2prim_id_None;
+  const ghl_con2prim_id_t backup_routine[3] = {None, None, None};
   const bool evolve_entropy = true;
   const bool evolve_temperature = false;
   const bool calc_prims_guess = true;

--- a/Unit_Tests/unit_test_grhayl_core_test_suite.c
+++ b/Unit_Tests/unit_test_grhayl_core_test_suite.c
@@ -248,7 +248,7 @@ int main(int argc, char **argv) {
   valid_char[7] = "Palenzuela1D_entropy";
   valid_char[8] = "Newman1D";
   valid_char[9] = "Newman1D_entropy";
-  for(int i = None; i <= Newman1D_entropy; i++) {
+  for(int i = ghl_con2prim_id_None; i <= ghl_con2prim_id_Newman1D_entropy; i++) {
     const char *test_char = ghl_get_con2prim_routine_name(i);
     if(strcmp(valid_char[i+1], test_char)) {
       ghl_error("ghl_get_con2prim_routine_name failed:\n    expected %s, got %s\n", valid_char[i+1], test_char);

--- a/Unit_Tests/unit_test_hybrid_failure.c
+++ b/Unit_Tests/unit_test_hybrid_failure.c
@@ -12,7 +12,8 @@ int main(int argc, char **argv) {
 
   // This section sets up the initial parameters that would normally
   // be provided by the simulation.
-  const int backup_routine[3] = {Noble2D,Noble2D,Noble2D};
+  const ghl_con2prim_id_t Noble2D = ghl_con2prim_id_Noble2D;
+  const ghl_con2prim_id_t backup_routine[3] = {Noble2D, Noble2D, Noble2D};
   const bool evolve_entropy = false;
   const bool evolve_temperature = false;
   const bool calc_prims_guess = true;
@@ -132,26 +133,26 @@ int main(int argc, char **argv) {
 
     if(i==0) {
       // This just gets coverage for the success branches
-      params.main_routine = Font1D;
+      params.main_routine = ghl_con2prim_id_Font1D;
       int check = ghl_con2prim_hybrid_multi_method(&params, &eos, &ADM_metric, &metric_aux, &cons_undens, &prims, &diagnostics);
       if(check != 0)
         ghl_error("Font1D has returned a different failure code: old %d and new %d", 0, check);
-      params.main_routine = Noble2D;
+      params.main_routine = ghl_con2prim_id_Noble2D;
       for (int j=0; j<3; j++) {
-        params.backup_routine[2-j] = Font1D;
+        params.backup_routine[2-j] = ghl_con2prim_id_Font1D;
         int check = ghl_con2prim_hybrid_multi_method(&params, &eos, &ADM_metric, &metric_aux, &cons_undens, &prims, &diagnostics);
         if(check != 0)
           ghl_error("Font1D has returned a different failure code: old %d and new %d", 0, check);
-        params.backup_routine[2-j] = Noble2D;
+        params.backup_routine[2-j] = ghl_con2prim_id_Noble2D;
       }
       params.calc_prim_guess = true;
     } else if (i==3) {
       // Here, we can check the Font Fix failure condition (there's just one return value)
-      params.backup_routine[0] = Font1D;
+      params.backup_routine[0] = ghl_con2prim_id_Font1D;
       int check = ghl_con2prim_hybrid_multi_method(&params, &eos, &ADM_metric, &metric_aux, &cons_undens, &prims, &diagnostics);
       if(check != ghl_error_c2p_max_iter)
         ghl_error("Font1D has returned a different failure code: old %d and new %d", 1, check);
-      params.backup_routine[0] = None;
+      params.backup_routine[0] = ghl_con2prim_id_None;
     }
   }
   return 0;

--- a/Unit_Tests/unit_test_tabulated_eos.c
+++ b/Unit_Tests/unit_test_tabulated_eos.c
@@ -465,7 +465,8 @@ int main(int argc, char **argv) {
 
   // Enforce limit tests
   {
-    const int backup_routine[3] = {None, None, None};
+    const ghl_con2prim_id_t None = ghl_con2prim_id_None;
+    const ghl_con2prim_id_t backup_routine[3] = {None, None, None};
     const bool calc_prims_guess = true;
     const double Psi6threshold = 1e100;
     const double W_max = 10.0;

--- a/implementations/GRHayLib/src/initialize_and_shutdown.c
+++ b/implementations/GRHayLib/src/initialize_and_shutdown.c
@@ -176,6 +176,7 @@ void GRHayLib_initialize(CCTK_ARGUMENTS) {
       ghl_params->ppm_shock_k0      = ppm_shock_k0;
 
   if (CCTK_EQUALS(EOS_type, "Simple")) {
+    const ghl_con2prim_id_t Font1D = ghl_con2prim_id_Font1D;
     if(main == Font1D || backups[0] == Font1D || backups[1] == Font1D || backups[2] == Font1D)
       CCTK_VERROR("Error: Font1D routine is incompatible with ideal fluid EOS. Please choose a different Con2Prim routine.");
     ghl_con2prim_multi_method = ghl_con2prim_hybrid_multi_method;
@@ -227,25 +228,25 @@ void GRHayLib_terminate(CCTK_ARGUMENTS) {
 
 int parse_C2P_routine_keyword(const char *restrict routine_name) {
   if (CCTK_EQUALS(routine_name, "None")) {
-    return None;
+    return ghl_con2prim_id_None;
   } else if (CCTK_EQUALS(routine_name, "Noble2D")) {
-    return Noble2D;
+    return ghl_con2prim_id_Noble2D;
   } else if (CCTK_EQUALS(routine_name, "Noble1D")) {
-    return Noble1D;
+    return ghl_con2prim_id_Noble1D;
   } else if (CCTK_EQUALS(routine_name, "Noble1D_entropy")) {
-    return Noble1D_entropy;
+    return ghl_con2prim_id_Noble1D_entropy;
   } else if (CCTK_EQUALS(routine_name, "Noble1D_entropy2")) {
-    return Noble1D_entropy2;
+    return ghl_con2prim_id_Noble1D_entropy2;
   } else if (CCTK_EQUALS(routine_name, "Font1D")) {
-    return Font1D;
+    return ghl_con2prim_id_Font1D;
   } else if (CCTK_EQUALS(routine_name, "Palenzuela1D")) {
-    return Palenzuela1D;
+    return ghl_con2prim_id_Palenzuela1D;
   } else if (CCTK_EQUALS(routine_name, "Palenzuela1D_entropy")) {
-    return Palenzuela1D_entropy;
+    return ghl_con2prim_id_Palenzuela1D_entropy;
   } else if (CCTK_EQUALS(routine_name, "Newman1D")) {
-    return Newman1D;
+    return ghl_con2prim_id_Newman1D;
   } else if (CCTK_EQUALS(routine_name, "Newman1D_entropy")) {
-    return Newman1D_entropy;
+    return ghl_con2prim_id_Newman1D_entropy;
   }
   return -100;
 }


### PR DESCRIPTION
This PR renames the `ghl_con2prim_method_t` enum to `ghl_con2prim_id_t`, while also adding the prefix `ghl_con2prim_id_` to all exported variables in the named enum, to avoid polluting the namespace. The previously exported `None` keyword was particularly problematic, as it wasn't descriptive and is a common enough keyword that could clash with external code.