### PR TITLE
Renamed ADM_metric -> metric_adm

### DIFF
--- a/GRHayL/Con2Prim/Hybrid/Font1D/hybrid_Font1D.c
+++ b/GRHayL/Con2Prim/Hybrid/Font1D/hybrid_Font1D.c
@@ -34,7 +34,7 @@ ghl_error_codes_t ghl_hybrid_Font1D_loop(
  *
  * @param[in] eos pointer to ghl_eos_parameters struct
  *
- * @param[in] ADM_metric pointer to ghl_metric_quantities struct with ADM metric
+ * @param[in] metric_adm pointer to ghl_metric_quantities struct with ADM metric
  *
  * @param[in] metric_aux pointer to ghl_ADM_aux_quantities struct
  *
@@ -55,7 +55,7 @@ ghl_error_codes_t ghl_hybrid_Font1D_loop(
 ghl_error_codes_t ghl_hybrid_Font1D(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prims,
@@ -63,7 +63,7 @@ ghl_error_codes_t ghl_hybrid_Font1D(
 
   double utU[3];
 
-  const double sdots = ghl_compute_vec2_from_vec3D(ADM_metric->gammaUU, cons->SD);
+  const double sdots = ghl_compute_vec2_from_vec3D(metric_adm->gammaUU, cons->SD);
   /**
    * # Function Step-by-Step
    *
@@ -74,7 +74,7 @@ ghl_error_codes_t ghl_hybrid_Font1D(
    * velocity is zero and skip the iterative solve.
    */
 
-  const double B2 = ghl_compute_vec2_from_vec3D(ADM_metric->gammaDD, prims->BU);
+  const double B2 = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, prims->BU);
 
   double BdotS, BdotS2, hatBdotS;
   if(B2 < 1e-150) {
@@ -86,17 +86,17 @@ ghl_error_codes_t ghl_hybrid_Font1D(
     hatBdotS = BdotS/B_mag;
   }
 
-  double Psim6 = 1.0/ADM_metric->sqrt_detgamma;
+  double Psim6 = 1.0/metric_adm->sqrt_detgamma;
 
   double rhob;
   if (sdots<1.e-300) {
     utU[0] = 0.0;
     utU[1] = 0.0;
     utU[2] = 0.0;
-    prims->u0    = ADM_metric->lapseinv;
-    prims->vU[0] = -ADM_metric->betaU[0];
-    prims->vU[1] = -ADM_metric->betaU[1];
-    prims->vU[2] = -ADM_metric->betaU[2];
+    prims->u0    = metric_adm->lapseinv;
+    prims->vU[0] = -metric_adm->betaU[0];
+    prims->vU[1] = -metric_adm->betaU[1];
+    prims->vU[2] = -metric_adm->betaU[2];
   } else {
     double W0    = sqrt( SQR(hatBdotS) + SQR(cons->rho) ) * Psim6;
     double Sf20  = (SQR(W0)*sdots + BdotS2*(B2 + 2.0*W0))/SQR(W0+B2);
@@ -175,19 +175,19 @@ ghl_error_codes_t ghl_hybrid_Font1D(
      *              + \frac{\sqrt{|\gamma|} B^2}{\gamma_v} \right]^{-1}
      * \f]
      */
-    double fac1 = ADM_metric->sqrt_detgamma*BdotS/(gammav*rhosh);
-    double fac2 = 1.0/(rhosh + ADM_metric->sqrt_detgamma*B2/gammav);
+    double fac1 = metric_adm->sqrt_detgamma*BdotS/(gammav*rhosh);
+    double fac2 = 1.0/(rhosh + metric_adm->sqrt_detgamma*B2/gammav);
 
     double SU[3];
-    ghl_raise_lower_vector_3D(ADM_metric->gammaUU, cons->SD, SU);
+    ghl_raise_lower_vector_3D(metric_adm->gammaUU, cons->SD, SU);
 
     utU[0] = fac2*(SU[0] + fac1*prims->BU[0]);
     utU[1] = fac2*(SU[1] + fac1*prims->BU[1]);
     utU[2] = fac2*(SU[2] + fac1*prims->BU[2]);
-    diagnostics->speed_limited = ghl_limit_utilde_and_compute_v(params, ADM_metric, utU, prims);
+    diagnostics->speed_limited = ghl_limit_utilde_and_compute_v(params, metric_adm, utU, prims);
   }
 
-  prims->rho = cons->rho/(ADM_metric->lapse*prims->u0*ADM_metric->sqrt_detgamma);
+  prims->rho = cons->rho/(metric_adm->lapse*prims->u0*metric_adm->sqrt_detgamma);
   /**
    * The Font fix only sets the velocities. We set the remaining primitives using
    * @ref ghl_hybrid_compute_P_cold, @ref ghl_hybrid_compute_entropy_function,

--- a/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D.c
@@ -36,7 +36,7 @@
  *
  * @param[in] eos pointer to ghl_eos_parameters struct
  *
- * @param[in] ADM_metric pointer to ghl_metric_quantities struct with ADM metric
+ * @param[in] metric_adm pointer to ghl_metric_quantities struct with ADM metric
  *
  * @param[in] metric_aux pointer to ghl_ADM_aux_quantities struct
  *
@@ -56,7 +56,7 @@
 ghl_error_codes_t ghl_hybrid_Noble1D(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -68,7 +68,7 @@ ghl_error_codes_t ghl_hybrid_Noble1D(
 
   // Calculate Z:
   ghl_error_codes_t error = ghl_initialize_Noble(
-        params, eos, ADM_metric, metric_aux, cons_undens,
+        params, eos, metric_adm, metric_aux, cons_undens,
         prims, &harm_aux, &gnr_out[0]);
   if(error)
     return error;
@@ -99,7 +99,7 @@ ghl_error_codes_t ghl_hybrid_Noble1D(
   }
 
   // Recover the primitive variables from the scalars and conserved variables:
-  diagnostics->speed_limited = ghl_finalize_Noble(params, eos, ADM_metric, metric_aux, cons_undens, &harm_aux, Z, vsq, prims);
+  diagnostics->speed_limited = ghl_finalize_Noble(params, eos, metric_adm, metric_aux, cons_undens, &harm_aux, Z, vsq, prims);
   if(prims->press <= 0.0) {
     return ghl_error_neg_pressure;
   }

--- a/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D_entropy.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D_entropy.c
@@ -37,7 +37,7 @@
  *
  * @param[in] eos pointer to ghl_eos_parameters struct
  *
- * @param[in] ADM_metric pointer to ghl_metric_quantities struct with ADM metric
+ * @param[in] metric_adm pointer to ghl_metric_quantities struct with ADM metric
  *
  * @param[in] metric_aux pointer to ghl_ADM_aux_quantities struct
  *
@@ -57,7 +57,7 @@
 ghl_error_codes_t ghl_hybrid_Noble1D_entropy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -69,7 +69,7 @@ ghl_error_codes_t ghl_hybrid_Noble1D_entropy(
 
   double rho0, Z_last;
   ghl_error_codes_t error = ghl_initialize_Noble_entropy(
-        params, eos, ADM_metric, metric_aux, cons_undens,
+        params, eos, metric_adm, metric_aux, cons_undens,
         prims, &harm_aux, &rho0, &Z_last);
   if(error)
     return error;
@@ -137,7 +137,7 @@ ghl_error_codes_t ghl_hybrid_Noble1D_entropy(
     return ghl_error_neg_rho;
   }
 
-  diagnostics->speed_limited = ghl_finalize_Noble_entropy(params, eos, ADM_metric, metric_aux, cons_undens, &harm_aux, Z, W, prims);
+  diagnostics->speed_limited = ghl_finalize_Noble_entropy(params, eos, metric_adm, metric_aux, cons_undens, &harm_aux, Z, W, prims);
   if(prims->press <= 0.0) {
     return ghl_error_neg_pressure;
   }

--- a/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D_entropy2.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/Noble1D/hybrid_Noble1D_entropy2.c
@@ -64,7 +64,7 @@ TODO: needs remaining error codes
 ghl_error_codes_t ghl_hybrid_Noble1D_entropy2(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -75,7 +75,7 @@ ghl_error_codes_t ghl_hybrid_Noble1D_entropy2(
   harm_aux_vars_struct harm_aux;
 
   double rho0, Z_last;
-  if( ghl_initialize_Noble_entropy(params, eos, ADM_metric, metric_aux,
+  if( ghl_initialize_Noble_entropy(params, eos, metric_adm, metric_aux,
                                    cons_undens, prims, &harm_aux, &rho0, &Z_last) )
     return 1;
 
@@ -120,7 +120,7 @@ ghl_error_codes_t ghl_hybrid_Noble1D_entropy2(
     return ghl_error_neg_rho;
   }
 
-  diagnostics->speed_limited = ghl_finalize_Noble_entropy(params, eos, ADM_metric, metric_aux, cons_undens, &harm_aux, Z, W, prims);
+  diagnostics->speed_limited = ghl_finalize_Noble_entropy(params, eos, metric_adm, metric_aux, cons_undens, &harm_aux, Z, W, prims);
   if(prims->press <= 0.0) {
     return ghl_error_neg_pressure;
   }

--- a/GRHayL/Con2Prim/Hybrid/Noble/Noble2D/hybrid_Noble2D.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/Noble2D/hybrid_Noble2D.c
@@ -36,7 +36,7 @@
  *
  * @param[in] eos pointer to ghl_eos_parameters struct
  *
- * @param[in] ADM_metric pointer to ghl_metric_quantities struct with ADM metric
+ * @param[in] metric_adm pointer to ghl_metric_quantities struct with ADM metric
  *
  * @param[in] metric_aux pointer to ghl_ADM_aux_quantities struct
  *
@@ -56,7 +56,7 @@
 ghl_error_codes_t ghl_hybrid_Noble2D(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -68,7 +68,7 @@ ghl_error_codes_t ghl_hybrid_Noble2D(
 
   // Calculate Z and vsq:
   ghl_error_codes_t error = ghl_initialize_Noble(
-        params, eos, ADM_metric, metric_aux, cons_undens,
+        params, eos, metric_adm, metric_aux, cons_undens,
         prims, &harm_aux, &gnr_out[0]);
   if(error)
     return error;
@@ -98,7 +98,7 @@ ghl_error_codes_t ghl_hybrid_Noble2D(
   }
 
   // Recover the primitive variables from the scalars and conserved variables:
-  diagnostics->speed_limited = ghl_finalize_Noble(params, eos, ADM_metric, metric_aux, cons_undens, &harm_aux, Z, vsq, prims);
+  diagnostics->speed_limited = ghl_finalize_Noble(params, eos, metric_adm, metric_aux, cons_undens, &harm_aux, Z, vsq, prims);
   if(prims->press <= 0.0) {
     return ghl_error_neg_pressure;
   }

--- a/GRHayL/Con2Prim/Hybrid/Noble/finalize_Noble.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/finalize_Noble.c
@@ -3,7 +3,7 @@
 bool ghl_finalize_Noble(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       const harm_aux_vars_struct *restrict harm_aux,
@@ -15,10 +15,10 @@ bool ghl_finalize_Noble(
   const double W = 1.0/gtmp;
   const double w = Z * (1.0 - vsq);
 
-  const double nU[4] = {ADM_metric->lapseinv,
-                       -ADM_metric->lapseinv*ADM_metric->betaU[0],
-                       -ADM_metric->lapseinv*ADM_metric->betaU[1],
-                       -ADM_metric->lapseinv*ADM_metric->betaU[2]};
+  const double nU[4] = {metric_adm->lapseinv,
+                       -metric_adm->lapseinv*metric_adm->betaU[0],
+                       -metric_adm->lapseinv*metric_adm->betaU[1],
+                       -metric_adm->lapseinv*metric_adm->betaU[2]};
 
   const double g_o_ZBsq = W/(Z+harm_aux->Bsq);
   const double QdB_o_Z  = harm_aux->QdotB / Z;
@@ -32,11 +32,11 @@ bool ghl_finalize_Noble(
                    g_o_ZBsq * (Qtcon[2] + QdB_o_Z*prims->BU[1]),
                    g_o_ZBsq * (Qtcon[3] + QdB_o_Z*prims->BU[2])};
 
-  const bool speed_limited = ghl_limit_utilde_and_compute_v(params, ADM_metric, utU, prims);
+  const bool speed_limited = ghl_limit_utilde_and_compute_v(params, metric_adm, utU, prims);
 
   prims->rho = harm_aux->D * gtmp;
   if(speed_limited)
-    prims->rho = cons_undens->rho/(ADM_metric->lapse*prims->u0);
+    prims->rho = cons_undens->rho/(metric_adm->lapse*prims->u0);
 
   /*  Assumes hybrid EOS */
   prims->press = ghl_pressure_rho0_w(eos, prims->rho, w);
@@ -50,7 +50,7 @@ bool ghl_finalize_Noble(
 bool ghl_finalize_Noble_entropy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       const harm_aux_vars_struct *restrict harm_aux,
@@ -58,10 +58,10 @@ bool ghl_finalize_Noble_entropy(
       const double W,
       ghl_primitive_quantities *restrict prims) {
 
-  const double nU[4] = {ADM_metric->lapseinv,                                                         
-                       -ADM_metric->lapseinv*ADM_metric->betaU[0],                                    
-                       -ADM_metric->lapseinv*ADM_metric->betaU[1],                                    
-                       -ADM_metric->lapseinv*ADM_metric->betaU[2]};                                   
+  const double nU[4] = {metric_adm->lapseinv,                                                         
+                       -metric_adm->lapseinv*metric_adm->betaU[0],                                    
+                       -metric_adm->lapseinv*metric_adm->betaU[1],                                    
+                       -metric_adm->lapseinv*metric_adm->betaU[2]};                                   
 
   const double g_o_ZBsq = W/(Z+harm_aux->Bsq);
   const double QdB_o_Z  = harm_aux->QdotB / Z;
@@ -77,10 +77,10 @@ bool ghl_finalize_Noble_entropy(
 
   //Additional tabulated code here
 
-  const bool speed_limited = ghl_limit_utilde_and_compute_v(params, ADM_metric, utU, prims);
+  const bool speed_limited = ghl_limit_utilde_and_compute_v(params, metric_adm, utU, prims);
 
   if(speed_limited)
-    prims->rho = cons_undens->rho/(ADM_metric->lapse*prims->u0);                                      
+    prims->rho = cons_undens->rho/(metric_adm->lapse*prims->u0);                                      
 
   /*  Assumes hybrid EOS */
   const double Gamma_ppoly = eos->Gamma_ppoly[ghl_hybrid_find_polytropic_index(eos, prims->rho)];

--- a/GRHayL/Con2Prim/Hybrid/Noble/initialize_Noble.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/initialize_Noble.c
@@ -3,7 +3,7 @@
 ghl_error_codes_t ghl_initialize_Noble(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       const ghl_primitive_quantities *restrict prims,
@@ -14,13 +14,13 @@ ghl_error_codes_t ghl_initialize_Noble(
   harm_aux->max_iterations = params->con2prim_max_iterations;
   harm_aux->solver_tolerance = params->con2prim_solver_tolerance;
 
-  harm_aux->Bsq = ghl_compute_vec2_from_vec3D(ADM_metric->gammaDD, prims->BU);
+  harm_aux->Bsq = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, prims->BU);
 
-  const double uu = - cons_undens->tau*ADM_metric->lapse
-                    - ADM_metric->lapse*cons_undens->rho
-                    + ADM_metric->betaU[0]*cons_undens->SD[0]
-                    + ADM_metric->betaU[1]*cons_undens->SD[1]
-                    + ADM_metric->betaU[2]*cons_undens->SD[2];
+  const double uu = - cons_undens->tau*metric_adm->lapse
+                    - metric_adm->lapse*cons_undens->rho
+                    + metric_adm->betaU[0]*cons_undens->SD[0]
+                    + metric_adm->betaU[1]*cons_undens->SD[1]
+                    + metric_adm->betaU[2]*cons_undens->SD[2];
 
   const double QD[4] = {uu,
                         cons_undens->SD[0],
@@ -40,17 +40,17 @@ ghl_error_codes_t ghl_initialize_Noble(
   harm_aux->QdotBsq = harm_aux->QdotB*harm_aux->QdotB;
 
   // n_{\mu}Q^{\mu} = -alpha Q^{0}, since n_{\mu} = (-alpha,0,0,0)
-  harm_aux->Qdotn = -ADM_metric->lapse*harm_aux->QU[0];
+  harm_aux->Qdotn = -metric_adm->lapse*harm_aux->QU[0];
 
   harm_aux->Qtsq = Qsq + harm_aux->Qdotn*harm_aux->Qdotn;
 
   harm_aux->D    = cons_undens->rho;
 
   /* calculate Z from last timestep and use for guess */
-  const double utU_guess[3] = {prims->u0*(prims->vU[0] + ADM_metric->betaU[0]),
-                               prims->u0*(prims->vU[1] + ADM_metric->betaU[1]),
-                               prims->u0*(prims->vU[2] + ADM_metric->betaU[2])};
-  const double tmp_u = ghl_compute_vec2_from_vec3D(ADM_metric->gammaDD, utU_guess);
+  const double utU_guess[3] = {prims->u0*(prims->vU[0] + metric_adm->betaU[0]),
+                               prims->u0*(prims->vU[1] + metric_adm->betaU[1]),
+                               prims->u0*(prims->vU[2] + metric_adm->betaU[2])};
+  const double tmp_u = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, utU_guess);
 
   double utsq = tmp_u/(1.0-tmp_u);
 
@@ -88,7 +88,7 @@ ghl_error_codes_t ghl_initialize_Noble(
 ghl_error_codes_t ghl_initialize_Noble_entropy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       const ghl_primitive_quantities *restrict prims,
@@ -100,15 +100,15 @@ ghl_error_codes_t ghl_initialize_Noble_entropy(
   harm_aux->max_iterations = params->con2prim_max_iterations;
   harm_aux->solver_tolerance = params->con2prim_solver_tolerance;
 
-  harm_aux->Bsq = ghl_compute_vec2_from_vec3D(ADM_metric->gammaDD, prims->BU);
+  harm_aux->Bsq = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, prims->BU);
 
   harm_aux->W_times_S = cons_undens->entropy;
 
-  const double uu = - cons_undens->tau*ADM_metric->lapse
-                    - ADM_metric->lapse*cons_undens->rho
-                    + ADM_metric->betaU[0]*cons_undens->SD[0]
-                    + ADM_metric->betaU[1]*cons_undens->SD[1]
-                    + ADM_metric->betaU[2]*cons_undens->SD[2];
+  const double uu = - cons_undens->tau*metric_adm->lapse
+                    - metric_adm->lapse*cons_undens->rho
+                    + metric_adm->betaU[0]*cons_undens->SD[0]
+                    + metric_adm->betaU[1]*cons_undens->SD[1]
+                    + metric_adm->betaU[2]*cons_undens->SD[2];
 
   const double QD[4] = {uu,
                         cons_undens->SD[0],
@@ -128,17 +128,17 @@ ghl_error_codes_t ghl_initialize_Noble_entropy(
   harm_aux->QdotBsq = harm_aux->QdotB*harm_aux->QdotB;
 
   // n_{\mu}Q^{\mu} = -alpha Q^{0}, since n_{\mu} = (-alpha,0,0,0)
-  harm_aux->Qdotn = -ADM_metric->lapse*harm_aux->QU[0];
+  harm_aux->Qdotn = -metric_adm->lapse*harm_aux->QU[0];
 
   harm_aux->Qtsq = Qsq + harm_aux->Qdotn*harm_aux->Qdotn;
 
   harm_aux->D    = cons_undens->rho;
 
   /* calculate Z from last timestep and use for guess */
-  const double utU_guess[3] = {prims->u0*(prims->vU[0] + ADM_metric->betaU[0]),
-                               prims->u0*(prims->vU[1] + ADM_metric->betaU[1]),
-                               prims->u0*(prims->vU[2] + ADM_metric->betaU[2])};
-  const double tmp_u = ghl_compute_vec2_from_vec3D(ADM_metric->gammaDD, utU_guess);
+  const double utU_guess[3] = {prims->u0*(prims->vU[0] + metric_adm->betaU[0]),
+                               prims->u0*(prims->vU[1] + metric_adm->betaU[1]),
+                               prims->u0*(prims->vU[2] + metric_adm->betaU[2])};
+  const double tmp_u = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, utU_guess);
 
   double utsq = tmp_u/(1.0-tmp_u);
 

--- a/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D.c
+++ b/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D.c
@@ -62,13 +62,13 @@ ghl_error_codes_t ghl_hybrid_Palenzuela1D(
             double *restrict W_ptr),
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
       ghl_con2prim_diagnostics *restrict diagnostics) {
 
   double SU[3], B_squared, S_squared, BdotS;
-  ghl_compute_SU_Bsq_Ssq_BdotS(ADM_metric, cons_undens, prims, SU, &B_squared, &S_squared, &BdotS);
+  ghl_compute_SU_Bsq_Ssq_BdotS(metric_adm, cons_undens, prims, SU, &B_squared, &S_squared, &BdotS);
   const double tau = fmax(cons_undens->tau, eos->tau_atm);
 
   // Set specific quantities for this routine (Eq. A7 of [1])
@@ -110,7 +110,7 @@ ghl_error_codes_t ghl_hybrid_Palenzuela1D(
   };
 
   // Set prims struct
-  diagnostics->speed_limited = ghl_limit_utilde_and_compute_v(params, ADM_metric, utildeU, prims);
+  diagnostics->speed_limited = ghl_limit_utilde_and_compute_v(params, metric_adm, utildeU, prims);
   prims->entropy = ghl_hybrid_compute_entropy_function(eos, prims->rho, prims->press);
 
   return ghl_success;

--- a/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D_energy.c
+++ b/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D_energy.c
@@ -64,7 +64,7 @@ compute_rho_P_eps_W_energy(
 ghl_error_codes_t ghl_hybrid_Palenzuela1D_energy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -74,7 +74,7 @@ ghl_error_codes_t ghl_hybrid_Palenzuela1D_energy(
   return ghl_hybrid_Palenzuela1D(compute_rho_P_eps_W_energy,
                                  params,
                                  eos,
-                                 ADM_metric,
+                                 metric_adm,
                                  cons_undens,
                                  prims,
                                  diagnostics);

--- a/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D_entropy.c
+++ b/GRHayL/Con2Prim/Hybrid/Palenzuela1D/hybrid_Palenzuela1D_entropy.c
@@ -62,7 +62,7 @@ compute_rho_P_eps_W_entropy(
 ghl_error_codes_t ghl_hybrid_Palenzuela1D_entropy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -72,7 +72,7 @@ ghl_error_codes_t ghl_hybrid_Palenzuela1D_entropy(
   return ghl_hybrid_Palenzuela1D(compute_rho_P_eps_W_entropy,
                                  params,
                                  eos,
-                                 ADM_metric,
+                                 metric_adm,
                                  cons_undens,
                                  prims,
                                  diagnostics);

--- a/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_energy.c
+++ b/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_energy.c
@@ -7,7 +7,7 @@ static ghl_error_codes_t ghl_newman_energy(
       const double BdotS,
       const double B_squared,
       const double *restrict SU,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_conservative_quantities *restrict con,
       ghl_primitive_quantities *restrict prims,
       const double tol_x,
@@ -133,7 +133,7 @@ static ghl_error_codes_t ghl_newman_energy(
   prims->Y_e         = xye;
   prims->temperature = xtemp;
   ghl_tabulated_enforce_bounds_rho_Ye_T(eos, &prims->rho, &prims->Y_e, &prims->temperature);
-  diagnostics->speed_limited = ghl_limit_utilde_and_compute_v(params, ADM_metric, utildeU, prims);
+  diagnostics->speed_limited = ghl_limit_utilde_and_compute_v(params, metric_adm, utildeU, prims);
   ghl_tabulated_compute_P_eps_S_from_T(eos, prims->rho, prims->Y_e, prims->temperature,
                                        &prims->press, &prims->eps, &prims->entropy);
 
@@ -143,7 +143,7 @@ static ghl_error_codes_t ghl_newman_energy(
 ghl_error_codes_t ghl_tabulated_Newman1D_energy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -151,18 +151,18 @@ ghl_error_codes_t ghl_tabulated_Newman1D_energy(
 
   // Step 1: Compute auxiliary quantities
   double SU[3], Bsq, Ssq, BdotS;
-  ghl_compute_SU_Bsq_Ssq_BdotS(ADM_metric, cons_undens, prims, SU, &Bsq, &Ssq, &BdotS);
+  ghl_compute_SU_Bsq_Ssq_BdotS(metric_adm, cons_undens, prims, SU, &Bsq, &Ssq, &BdotS);
 
   // Step 2: Call the Newman routine that uses the energy to recover T
   const double tol_x = 1e-15;
   diagnostics->which_routine = ghl_con2prim_id_Newman1D;
 
-  ghl_error_codes_t error = ghl_newman_energy(params, eos, Ssq, BdotS, Bsq, SU, ADM_metric,
+  ghl_error_codes_t error = ghl_newman_energy(params, eos, Ssq, BdotS, Bsq, SU, metric_adm,
 				cons_undens, prims, tol_x, diagnostics);
 
   if(error) {
     prims->temperature = eos->T_min;
-    error = ghl_newman_energy(params, eos, Ssq, BdotS, Bsq, SU, ADM_metric,
+    error = ghl_newman_energy(params, eos, Ssq, BdotS, Bsq, SU, metric_adm,
 			      cons_undens, prims, tol_x, diagnostics);
   }
   return error;

--- a/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_entropy.c
+++ b/GRHayL/Con2Prim/Tabulated/Newman1D/tabulated_Newman1D_entropy.c
@@ -7,7 +7,7 @@ static ghl_error_codes_t ghl_newman_entropy(
       const double BdotS,
       const double B_squared,
       const double *restrict SU,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_conservative_quantities *restrict con,
       ghl_primitive_quantities *restrict prims,
       const double tol_x,
@@ -125,7 +125,7 @@ static ghl_error_codes_t ghl_newman_entropy(
   prims->Y_e         = xye;
   prims->temperature = xtemp;
   ghl_tabulated_enforce_bounds_rho_Ye_T(eos, &prims->rho, &prims->Y_e, &prims->temperature);
-  diagnostics->speed_limited = ghl_limit_utilde_and_compute_v(params, ADM_metric, utildeU, prims);
+  diagnostics->speed_limited = ghl_limit_utilde_and_compute_v(params, metric_adm, utildeU, prims);
   ghl_tabulated_compute_P_eps_S_from_T(eos, prims->rho, prims->Y_e, prims->temperature,
                                        &prims->press, &prims->eps, &prims->entropy);
 
@@ -135,7 +135,7 @@ static ghl_error_codes_t ghl_newman_entropy(
 ghl_error_codes_t ghl_tabulated_Newman1D_entropy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -143,18 +143,18 @@ ghl_error_codes_t ghl_tabulated_Newman1D_entropy(
 
   // Step 1: Compute auxiliary quantities
   double SU[3], Bsq, Ssq, BdotS;
-  ghl_compute_SU_Bsq_Ssq_BdotS(ADM_metric, cons_undens, prims, SU, &Bsq, &Ssq, &BdotS);
+  ghl_compute_SU_Bsq_Ssq_BdotS(metric_adm, cons_undens, prims, SU, &Bsq, &Ssq, &BdotS);
 
   // Step 2: Call the Newman routine that uses the entropy to recover T
   const double tol_x = 1e-15;
   diagnostics->which_routine = ghl_con2prim_id_Newman1D_entropy;
 
-  ghl_error_codes_t error = ghl_newman_entropy(params, eos, Ssq, BdotS, Bsq, SU, ADM_metric,
+  ghl_error_codes_t error = ghl_newman_entropy(params, eos, Ssq, BdotS, Bsq, SU, metric_adm,
 				 cons_undens, prims, tol_x, diagnostics);
 
   if(error) {
     prims->temperature = eos->T_min;
-    error = ghl_newman_entropy(params, eos, Ssq, BdotS, Bsq, SU, ADM_metric,
+    error = ghl_newman_entropy(params, eos, Ssq, BdotS, Bsq, SU, metric_adm,
 			       cons_undens, prims, tol_x, diagnostics);
   }
 

--- a/GRHayL/Con2Prim/Tabulated/Palenzuela1D/tabulated_Palenzuela1D.c
+++ b/GRHayL/Con2Prim/Tabulated/Palenzuela1D/tabulated_Palenzuela1D.c
@@ -62,13 +62,13 @@ ghl_error_codes_t ghl_tabulated_Palenzuela1D(
             double *restrict W_ptr),
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
       ghl_con2prim_diagnostics *restrict diagnostics) {
 
   double SU[3], B_squared, S_squared, BdotS;
-  ghl_compute_SU_Bsq_Ssq_BdotS(ADM_metric, cons_undens, prims, SU, &B_squared, &S_squared, &BdotS);
+  ghl_compute_SU_Bsq_Ssq_BdotS(metric_adm, cons_undens, prims, SU, &B_squared, &S_squared, &BdotS);
   const double tau = fmax(cons_undens->tau, eos->tau_atm);
 
   // Set specific quantities for this routine (Eq. A7 of [1])
@@ -116,7 +116,7 @@ ghl_error_codes_t ghl_tabulated_Palenzuela1D(
 
   // Set prims struct
   ghl_tabulated_enforce_bounds_rho_Ye_T(eos, &prims->rho, &prims->Y_e, &prims->temperature);
-  diagnostics->speed_limited = ghl_limit_utilde_and_compute_v(params, ADM_metric, utildeU, prims);
+  diagnostics->speed_limited = ghl_limit_utilde_and_compute_v(params, metric_adm, utildeU, prims);
   ghl_tabulated_compute_P_eps_S_from_T(eos, prims->rho, prims->Y_e, prims->temperature,
                                        &prims->press, &prims->eps, &prims->entropy);
 

--- a/GRHayL/Con2Prim/Tabulated/Palenzuela1D/tabulated_Palenzuela1D_energy.c
+++ b/GRHayL/Con2Prim/Tabulated/Palenzuela1D/tabulated_Palenzuela1D_energy.c
@@ -71,7 +71,7 @@ compute_rho_P_eps_T_W_energy(
 ghl_error_codes_t ghl_tabulated_Palenzuela1D_energy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -81,7 +81,7 @@ ghl_error_codes_t ghl_tabulated_Palenzuela1D_energy(
   return ghl_tabulated_Palenzuela1D(compute_rho_P_eps_T_W_energy,
                                 params,
                                 eos,
-                                ADM_metric,
+                                metric_adm,
                                 cons_undens,
                                 prims,
                                 diagnostics);

--- a/GRHayL/Con2Prim/Tabulated/Palenzuela1D/tabulated_Palenzuela1D_entropy.c
+++ b/GRHayL/Con2Prim/Tabulated/Palenzuela1D/tabulated_Palenzuela1D_entropy.c
@@ -65,7 +65,7 @@ compute_rho_P_eps_T_W_entropy(
 ghl_error_codes_t ghl_tabulated_Palenzuela1D_entropy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -76,7 +76,7 @@ ghl_error_codes_t ghl_tabulated_Palenzuela1D_entropy(
                compute_rho_P_eps_T_W_entropy,
                params,
                eos,
-               ADM_metric,
+               metric_adm,
                cons_undens,
                prims,
                diagnostics);

--- a/GRHayL/Con2Prim/apply_conservative_limits.c
+++ b/GRHayL/Con2Prim/apply_conservative_limits.c
@@ -18,7 +18,7 @@
  *
  * @param[in] eos pointer to ghl_eos_parameters struct
  *
- * @param[in] ADM_metric pointer to ghl_metric_quantities struct with ADM metric
+ * @param[in] metric_adm pointer to ghl_metric_quantities struct with ADM metric
  *
  * @param[in] prims pointer to ghl_primitive_quantities struct
  *
@@ -32,7 +32,7 @@
 void ghl_apply_conservative_limits(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_primitive_quantities *restrict prims,
       ghl_conservative_quantities *restrict cons,
       ghl_con2prim_diagnostics *restrict diagnostics) {
@@ -45,9 +45,9 @@ void ghl_apply_conservative_limits(
    * @ref ghl_compute_vec2_from_vec3D(). Then, we compute \f$ B\cdot S \f$,
    * \f$ \hat{B}\cdot S \f$ and some other intermediate quantities:
    */
-  const double sdots = ghl_compute_vec2_from_vec3D(ADM_metric->gammaUU, cons->SD);
+  const double sdots = ghl_compute_vec2_from_vec3D(metric_adm->gammaUU, cons->SD);
 
-  const double B2 = ghl_compute_vec2_from_vec3D(ADM_metric->gammaDD, prims->BU);
+  const double B2 = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, prims->BU);
 
   /**
    * To prevent possible [floating-point underflow](https://en.wikipedia.org/wiki/Arithmetic_underflow)
@@ -77,7 +77,7 @@ void ghl_apply_conservative_limits(
      * W_m \equiv \mathrm{\texttt{Wm}} = \frac{\sqrt{\hat{\Omega}^2 + \tilde{D}^2}}{\sqrt{\gamma}}
      * \f]
      */
-    const double Wm = sqrt(SQR(hatBdotS) + SQR(cons->rho))/ADM_metric->sqrt_detgamma;
+    const double Wm = sqrt(SQR(hatBdotS) + SQR(cons->rho))/metric_adm->sqrt_detgamma;
     /**
      * \f[
      * S_m^2 \equiv \mathrm{\texttt{Sm2}}
@@ -92,8 +92,8 @@ void ghl_apply_conservative_limits(
      *   = \frac{\sqrt{S_m^2 + \tilde{D}^2}}{\sqrt{\gamma}}
      * \f]
      */
-    const double Wmin = sqrt(Sm2 + SQR(cons->rho))/ADM_metric->sqrt_detgamma;
-    half_psi6_B2 = 0.5*ADM_metric->sqrt_detgamma*B2;
+    const double Wmin = sqrt(Sm2 + SQR(cons->rho))/metric_adm->sqrt_detgamma;
+    half_psi6_B2 = 0.5*metric_adm->sqrt_detgamma*B2;
     /**
      * \f[
      * \tilde{\tau}_3 \equiv \mathrm{\texttt{tau_fluid_term3}}
@@ -101,7 +101,7 @@ void ghl_apply_conservative_limits(
      *   - \Omega^2}{2 \sqrt{\gamma}\left( W_\mathrm{min} + B^2\right)^2}
      * \f]
      */
-    tau_fluid_term3 = (B2*sdots - SQR(BdotS))*0.5/(ADM_metric->sqrt_detgamma*SQR(Wmin+B2));
+    tau_fluid_term3 = (B2*sdots - SQR(BdotS))*0.5/(metric_adm->sqrt_detgamma*SQR(Wmin+B2));
   }
 
   /**
@@ -174,7 +174,7 @@ void ghl_apply_conservative_limits(
    *               (\tilde{\tau}_\mathrm{fluid,min} + 2\tilde{D})}{\tilde{S}^2}}
    * \f]
    */
-  } else if(ADM_metric->sqrt_detgamma>params->psi6threshold) {
+  } else if(metric_adm->sqrt_detgamma>params->psi6threshold) {
     double tau_fluid_min = cons->tau - half_psi6_B2 - tau_fluid_term3;
     if (tau_fluid_min < eos->tau_atm*1.001) {
       tau_fluid_min = eos->tau_atm*1.001;

--- a/GRHayL/Con2Prim/compute_SU_Bsq_Ssq_BdotS.c
+++ b/GRHayL/Con2Prim/compute_SU_Bsq_Ssq_BdotS.c
@@ -17,7 +17,7 @@
  * Returns    : Nothing.
  */
 void ghl_compute_SU_Bsq_Ssq_BdotS(
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_conservative_quantities *restrict cons_undens,
       const ghl_primitive_quantities *restrict prims,
       double *restrict SU,
@@ -27,7 +27,7 @@ void ghl_compute_SU_Bsq_Ssq_BdotS(
 
   // Step 1: Compute S^{2} = gamma^{ij}S_{i}S_{j}
   double SD[3] = {cons_undens->SD[0], cons_undens->SD[1], cons_undens->SD[2]};
-  double S_squared = ghl_compute_vec2_from_vec3D(ADM_metric->gammaUU, SD);
+  double S_squared = ghl_compute_vec2_from_vec3D(metric_adm->gammaUU, SD);
 
   // Step 2: Enforce ceiling on S^{2} (Eq. A5 of [1])
   // Step 2.1: Compute maximum allowed value for S^{2}
@@ -39,16 +39,16 @@ void ghl_compute_SU_Bsq_Ssq_BdotS(
       SD[i] *= rescale_factor;
 
     // Step 2.3: Recompute S^{2}
-    S_squared = ghl_compute_vec2_from_vec3D(ADM_metric->gammaUU, SD);
+    S_squared = ghl_compute_vec2_from_vec3D(metric_adm->gammaUU, SD);
   }
   *Ssq = S_squared;
 
   // Step 3: Compute B^{2} = gamma_{ij}B^{i}B^{j}
-  *Bsq = ghl_compute_vec2_from_vec3D(ADM_metric->gammaDD, prims->BU);
+  *Bsq = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, prims->BU);
 
   // Step 4: Compute B.S = B^{i}S_{i}
   *BdotS = prims->BU[0]*SD[0] + prims->BU[1]*SD[1] + prims->BU[2]*SD[2];
 
   // Step 5: Compute S^{i}
-  ghl_raise_lower_vector_3D(ADM_metric->gammaUU, SD, SU);
+  ghl_raise_lower_vector_3D(metric_adm->gammaUU, SD, SU);
 }

--- a/GRHayL/Con2Prim/compute_conservs.c
+++ b/GRHayL/Con2Prim/compute_conservs.c
@@ -9,7 +9,7 @@
  * variables, which is recommended after applying primitive limits to ensure
  * that the two variable sets are self-consistent.
  *
- * @param[in] ADM_metric pointer to ghl_metric_quantities struct with ADM metric
+ * @param[in] metric_adm pointer to ghl_metric_quantities struct with ADM metric
  *
  * @param[in] metric_aux pointer to ghl_ADM_aux_quantities struct
  *
@@ -21,7 +21,7 @@
  * @param[out] cons pointer to ghl_conservative_quantities struct
  */
 void ghl_compute_conservs(
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_primitive_quantities *restrict prims,
       ghl_conservative_quantities *restrict cons) {
@@ -65,10 +65,10 @@ void ghl_compute_conservs(
    * the conservative variables:
    */
   double smallb[4], smallb2;
-  ghl_compute_smallb_and_b2(ADM_metric, prims, uD, smallb, &smallb2);
+  ghl_compute_smallb_and_b2(metric_adm, prims, uD, smallb, &smallb2);
 
   // Precompute some useful quantities, for later:
-  const double alpha_sqrt_gamma = ADM_metric->lapse*ADM_metric->sqrt_detgamma;
+  const double alpha_sqrt_gamma = metric_adm->lapse*metric_adm->sqrt_detgamma;
   const double rho0_h_plus_b2 = (prims->rho*h_enthalpy + smallb2);
   const double P_plus_half_b2 = (prims->press+0.5*smallb2);
 
@@ -93,7 +93,7 @@ void ghl_compute_conservs(
   cons->SD[0] = cons->rho*h_enthalpy*uD[1] + alpha_sqrt_gamma*(uU[0]*smallb2*uD[1] - smallb[0]*smallb_lower[1]);
   cons->SD[1] = cons->rho*h_enthalpy*uD[2] + alpha_sqrt_gamma*(uU[0]*smallb2*uD[2] - smallb[0]*smallb_lower[2]);
   cons->SD[2] = cons->rho*h_enthalpy*uD[3] + alpha_sqrt_gamma*(uU[0]*smallb2*uD[3] - smallb[0]*smallb_lower[3]);
-  cons->tau = ADM_metric->lapse*alpha_sqrt_gamma*(rho0_h_plus_b2*SQR(uU[0]) - P_plus_half_b2*ADM_metric->lapseinv2 - SQR(smallb[0])) - cons->rho;
+  cons->tau = metric_adm->lapse*alpha_sqrt_gamma*(rho0_h_plus_b2*SQR(uU[0]) - P_plus_half_b2*metric_adm->lapseinv2 - SQR(smallb[0])) - cons->rho;
   cons->entropy = alpha_sqrt_gamma * prims->entropy * uU[0];
   cons->Y_e = cons->rho * prims->Y_e;
 }

--- a/GRHayL/Con2Prim/compute_conservs_and_Tmunu.c
+++ b/GRHayL/Con2Prim/compute_conservs_and_Tmunu.c
@@ -9,7 +9,7 @@
  * from the primitive variables, which is recommended after applying primitive
  * limits to ensure that the two variable sets are self-consistent.
  *
- * @param[in] ADM_metric pointer to ghl_metric_quantities struct with ADM metric
+ * @param[in] metric_adm pointer to ghl_metric_quantities struct with ADM metric
  *
  * @param[in] metric_aux pointer to ghl_ADM_aux_quantities struct
  *
@@ -23,7 +23,7 @@
  * @param[out] Tmunu pointer to ghl_stress_energy struct
  */
 void ghl_compute_conservs_and_Tmunu(
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_primitive_quantities *restrict prims,
       ghl_conservative_quantities *restrict cons,
@@ -68,10 +68,10 @@ void ghl_compute_conservs_and_Tmunu(
    * the conservative variables:
    */
   double smallb[4], smallb2;
-  ghl_compute_smallb_and_b2(ADM_metric, prims, uD, smallb, &smallb2);
+  ghl_compute_smallb_and_b2(metric_adm, prims, uD, smallb, &smallb2);
 
   // Precompute some useful quantities, for later:
-  const double alpha_sqrt_gamma = ADM_metric->lapse*ADM_metric->sqrt_detgamma;
+  const double alpha_sqrt_gamma = metric_adm->lapse*metric_adm->sqrt_detgamma;
   const double rho0_h_plus_b2 = (prims->rho*h_enthalpy + smallb2);
   const double P_plus_half_b2 = (prims->press+0.5*smallb2);
 
@@ -96,7 +96,7 @@ void ghl_compute_conservs_and_Tmunu(
   cons->SD[0] = cons->rho*h_enthalpy*uD[1] + alpha_sqrt_gamma*(uU[0]*smallb2*uD[1] - smallb[0]*smallb_lower[1]);
   cons->SD[1] = cons->rho*h_enthalpy*uD[2] + alpha_sqrt_gamma*(uU[0]*smallb2*uD[2] - smallb[0]*smallb_lower[2]);
   cons->SD[2] = cons->rho*h_enthalpy*uD[3] + alpha_sqrt_gamma*(uU[0]*smallb2*uD[3] - smallb[0]*smallb_lower[3]);
-  cons->tau = ADM_metric->lapse*alpha_sqrt_gamma*(rho0_h_plus_b2*SQR(uU[0]) - P_plus_half_b2*ADM_metric->lapseinv2 - SQR(smallb[0])) - cons->rho;
+  cons->tau = metric_adm->lapse*alpha_sqrt_gamma*(rho0_h_plus_b2*SQR(uU[0]) - P_plus_half_b2*metric_adm->lapseinv2 - SQR(smallb[0])) - cons->rho;
   cons->entropy = alpha_sqrt_gamma * prims->entropy * uU[0];
   cons->Y_e = cons->rho * prims->Y_e;
 

--- a/GRHayL/Con2Prim/con2prim_multi_method.c
+++ b/GRHayL/Con2Prim/con2prim_multi_method.c
@@ -10,7 +10,7 @@ ghl_error_codes_t ghl_con2prim_hybrid_select_method(
       const ghl_con2prim_id_t c2p_key,
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -19,20 +19,20 @@ ghl_error_codes_t ghl_con2prim_hybrid_select_method(
   switch(c2p_key) {
     // Noble routines (see https://arxiv.org/pdf/astro-ph/0512420.pdf)
     case ghl_con2prim_id_Noble2D:
-      return ghl_hybrid_Noble2D(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+      return ghl_hybrid_Noble2D(params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
     case ghl_con2prim_id_Noble1D:
-      return ghl_hybrid_Noble1D(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics); 
+      return ghl_hybrid_Noble1D(params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics); 
     // Font routine (see https://arxiv.org/abs/gr-qc/9811015)
     case ghl_con2prim_id_Font1D:
-      return ghl_hybrid_Font1D(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+      return ghl_hybrid_Font1D(params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
     // Palenzuela1D routine (see https://arxiv.org/pdf/1712.07538.pdf)
     case ghl_con2prim_id_Palenzuela1D:
-      return ghl_hybrid_Palenzuela1D_energy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+      return ghl_hybrid_Palenzuela1D_energy(params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
     // Entropy routines (see https://arxiv.org/abs/2208.14487)
     case ghl_con2prim_id_Noble1D_entropy:
-      return ghl_hybrid_Noble1D_entropy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics); 
+      return ghl_hybrid_Noble1D_entropy(params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics); 
     case ghl_con2prim_id_Palenzuela1D_entropy:
-      return ghl_hybrid_Palenzuela1D_entropy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+      return ghl_hybrid_Palenzuela1D_entropy(params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
     default:
       return ghl_error_invalid_c2p_key;
   }
@@ -48,7 +48,7 @@ ghl_error_codes_t ghl_con2prim_tabulated_select_method(
       const ghl_con2prim_id_t c2p_key,
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -60,15 +60,15 @@ ghl_error_codes_t ghl_con2prim_tabulated_select_method(
   switch(c2p_key) {
     // Palenzuela1D routine (see https://arxiv.org/pdf/1712.07538.pdf)
     case ghl_con2prim_id_Palenzuela1D:
-      return ghl_tabulated_Palenzuela1D_energy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+      return ghl_tabulated_Palenzuela1D_energy(params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
     // Newman 1D routine (see https://escholarship.org/uc/item/0s53f84b)
     case ghl_con2prim_id_Newman1D:
-      return ghl_tabulated_Newman1D_energy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+      return ghl_tabulated_Newman1D_energy(params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
     // Entropy routines (see https://arxiv.org/abs/2208.14487)
     case ghl_con2prim_id_Palenzuela1D_entropy:
-      return ghl_tabulated_Palenzuela1D_entropy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+      return ghl_tabulated_Palenzuela1D_entropy(params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
     case ghl_con2prim_id_Newman1D_entropy:
-      return ghl_tabulated_Newman1D_entropy(params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+      return ghl_tabulated_Newman1D_entropy(params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
     default:
       return ghl_error_invalid_c2p_key;
   }
@@ -84,19 +84,19 @@ ghl_error_codes_t ghl_con2prim_tabulated_select_method(
 ghl_error_codes_t ghl_con2prim_hybrid_multi_method(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
       ghl_con2prim_diagnostics *restrict diagnostics) {
 
   if(params->calc_prim_guess)
-    ghl_guess_primitives(eos, ADM_metric, cons_undens, prims);
+    ghl_guess_primitives(eos, metric_adm, cons_undens, prims);
 
   // Store primitive guesses (used if con2prim fails)
   const ghl_primitive_quantities prims_guess = *prims;
 
-  ghl_error_codes_t error = ghl_con2prim_hybrid_select_method(params->main_routine, params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+  ghl_error_codes_t error = ghl_con2prim_hybrid_select_method(params->main_routine, params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
 
   if(error && params->backup_routine[0] != ghl_con2prim_id_None) {
     // Backup 1 triggered
@@ -104,7 +104,7 @@ ghl_error_codes_t ghl_con2prim_hybrid_multi_method(
     // Reset guesses
     *prims = prims_guess;
     // Backup routine #1
-    error = ghl_con2prim_hybrid_select_method(params->backup_routine[0], params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+    error = ghl_con2prim_hybrid_select_method(params->backup_routine[0], params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
 
     if(error && params->backup_routine[1] != ghl_con2prim_id_None) {
       // Backup 2 triggered
@@ -112,7 +112,7 @@ ghl_error_codes_t ghl_con2prim_hybrid_multi_method(
       // Reset guesses
       *prims = prims_guess;
       // Backup routine #2
-      error = ghl_con2prim_hybrid_select_method(params->backup_routine[1], params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+      error = ghl_con2prim_hybrid_select_method(params->backup_routine[1], params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
 
       if(error && params->backup_routine[2] != ghl_con2prim_id_None) {
         // Backup 3 triggered
@@ -120,7 +120,7 @@ ghl_error_codes_t ghl_con2prim_hybrid_multi_method(
         // Reset guesses
         *prims = prims_guess;
         // Backup routine #3
-        error = ghl_con2prim_hybrid_select_method(params->backup_routine[2], params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+        error = ghl_con2prim_hybrid_select_method(params->backup_routine[2], params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
       }
     }
   }
@@ -136,7 +136,7 @@ ghl_error_codes_t ghl_con2prim_hybrid_multi_method(
 ghl_error_codes_t ghl_con2prim_tabulated_multi_method(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -146,12 +146,12 @@ ghl_error_codes_t ghl_con2prim_tabulated_multi_method(
   return ghl_error_used_disabled_hdf5;
 #else
   if(params->calc_prim_guess)
-    ghl_guess_primitives(eos, ADM_metric, cons_undens, prims);
+    ghl_guess_primitives(eos, metric_adm, cons_undens, prims);
 
   // Store primitive guesses (used if con2prim fails)
   const ghl_primitive_quantities prims_guess = *prims;
 
-  ghl_error_codes_t error = ghl_con2prim_tabulated_select_method(params->main_routine, params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+  ghl_error_codes_t error = ghl_con2prim_tabulated_select_method(params->main_routine, params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
 
   if(error && params->backup_routine[0] != ghl_con2prim_id_None) {
     // Backup 1 triggered
@@ -159,7 +159,7 @@ ghl_error_codes_t ghl_con2prim_tabulated_multi_method(
     // Reset guesses
     *prims = prims_guess;
     // Backup routine #1
-    error = ghl_con2prim_tabulated_select_method(params->backup_routine[0], params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+    error = ghl_con2prim_tabulated_select_method(params->backup_routine[0], params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
 
     if(error && params->backup_routine[1] != ghl_con2prim_id_None) {
       // Backup 2 triggered
@@ -167,7 +167,7 @@ ghl_error_codes_t ghl_con2prim_tabulated_multi_method(
       // Reset guesses
       *prims = prims_guess;
       // Backup routine #2
-      error = ghl_con2prim_tabulated_select_method(params->backup_routine[1], params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+      error = ghl_con2prim_tabulated_select_method(params->backup_routine[1], params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
 
       if(error && params->backup_routine[2] != ghl_con2prim_id_None) {
         // Backup 3 triggered
@@ -175,7 +175,7 @@ ghl_error_codes_t ghl_con2prim_tabulated_multi_method(
         // Reset guesses
         *prims = prims_guess;
         // Backup routine #3
-        error = ghl_con2prim_tabulated_select_method(params->backup_routine[2], params, eos, ADM_metric, metric_aux, cons_undens, prims, diagnostics);
+        error = ghl_con2prim_tabulated_select_method(params->backup_routine[2], params, eos, metric_adm, metric_aux, cons_undens, prims, diagnostics);
       }
     }
   }

--- a/GRHayL/Con2Prim/enforce_primitive_limits_and_compute_u0.c
+++ b/GRHayL/Con2Prim/enforce_primitive_limits_and_compute_u0.c
@@ -10,7 +10,7 @@
 ghl_error_codes_t ghl_enforce_primitive_limits_and_compute_u0(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       ghl_primitive_quantities *restrict prims,
       bool *restrict speed_limited) {
 
@@ -30,7 +30,7 @@ ghl_error_codes_t ghl_enforce_primitive_limits_and_compute_u0(
       // Set P_min and P_max
       const double P_min = P_cold;
 
-      const bool inhorizon = ADM_metric->sqrt_detgamma > params->psi6threshold;
+      const bool inhorizon = metric_adm->sqrt_detgamma > params->psi6threshold;
       // Adjust P_max based on Psi6
       const double P_max = inhorizon ? 1e5 * P_cold : 100.0 * P_cold;
 
@@ -91,5 +91,5 @@ ghl_error_codes_t ghl_enforce_primitive_limits_and_compute_u0(
   }
 
   // Finally, apply speed limit to v and compute u^0
-  return ghl_limit_v_and_compute_u0(params, ADM_metric, prims, speed_limited);
+  return ghl_limit_v_and_compute_u0(params, metric_adm, prims, speed_limited);
 }

--- a/GRHayL/Con2Prim/guess_primitives.c
+++ b/GRHayL/Con2Prim/guess_primitives.c
@@ -26,7 +26,7 @@
  *
  * @param[in] eos pointer to ghl_eos_parameters struct
  *
- * @param[in] ADM_metric pointer to ghl_metric_quantities struct with ADM metric
+ * @param[in] metric_adm pointer to ghl_metric_quantities struct with ADM metric
  *
  * @param[in] cons_undens pointer to ghl_conservative_quantities struct with
  *                        **undensitized** conservative variables
@@ -35,16 +35,16 @@
  */
 void ghl_guess_primitives(
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims) {
 
   // Use atmosphere as initial guess:
   prims->rho         = cons_undens->rho;
   prims->u0          = 1.0;
-  prims->vU[0]       = -ADM_metric->betaU[0];
-  prims->vU[1]       = -ADM_metric->betaU[1];
-  prims->vU[2]       = -ADM_metric->betaU[2];
+  prims->vU[0]       = -metric_adm->betaU[0];
+  prims->vU[1]       = -metric_adm->betaU[1];
+  prims->vU[2]       = -metric_adm->betaU[2];
   prims->Y_e         = cons_undens->Y_e/cons_undens->rho;
   prims->temperature = eos->T_max;
 

--- a/GRHayL/Con2Prim/limit_utilde_and_compute_v.c
+++ b/GRHayL/Con2Prim/limit_utilde_and_compute_v.c
@@ -14,7 +14,7 @@
  *
  * @param[in] params pointer to ghl_parameters struct
  *
- * @param[in] ADM_metric pointer to ghl_metric_quantities struct with ADM metric data
+ * @param[in] metric_adm pointer to ghl_metric_quantities struct with ADM metric data
  *
  * @param[in,out] utU spatial utilde variable \f$ \tilde{u}^i \f$
  *
@@ -24,13 +24,13 @@
  */
 bool ghl_limit_utilde_and_compute_v(
       const ghl_parameters *restrict params,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       double utU[3],
       ghl_primitive_quantities *restrict prims) {
 
   bool speed_limited = false;
   //Velocity limiter:
-  double ut2 = ghl_compute_vec2_from_vec3D(ADM_metric->gammaDD, utU);
+  double ut2 = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, utU);
   double au0m1 = ut2/( 1.0+sqrt(1.0+ut2) );
 
   // *** Limit velocity
@@ -45,9 +45,9 @@ bool ghl_limit_utilde_and_compute_v(
   } //Finished limiting velocity
 
   // Calculate v^i and u^0 from \tilde{u}^i
-  prims->u0 = (au0m1+1.0)*ADM_metric->lapseinv;
-  prims->vU[0] = utU[0]/prims->u0 - ADM_metric->betaU[0];
-  prims->vU[1] = utU[1]/prims->u0 - ADM_metric->betaU[1];
-  prims->vU[2] = utU[2]/prims->u0 - ADM_metric->betaU[2];
+  prims->u0 = (au0m1+1.0)*metric_adm->lapseinv;
+  prims->vU[0] = utU[0]/prims->u0 - metric_adm->betaU[0];
+  prims->vU[1] = utU[1]/prims->u0 - metric_adm->betaU[1];
+  prims->vU[2] = utU[2]/prims->u0 - metric_adm->betaU[2];
   return speed_limited;
 }

--- a/GRHayL/Con2Prim/utils_Noble.h
+++ b/GRHayL/Con2Prim/utils_Noble.h
@@ -238,7 +238,7 @@ void ghl_func_2D(
 ghl_error_codes_t ghl_initialize_Noble(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       const ghl_primitive_quantities *restrict prims,
@@ -248,7 +248,7 @@ ghl_error_codes_t ghl_initialize_Noble(
 ghl_error_codes_t ghl_initialize_Noble_entropy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       const ghl_primitive_quantities *restrict prims,
@@ -259,7 +259,7 @@ ghl_error_codes_t ghl_initialize_Noble_entropy(
 bool ghl_finalize_Noble(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       const harm_aux_vars_struct *restrict harm_aux,
@@ -270,7 +270,7 @@ bool ghl_finalize_Noble(
 bool ghl_finalize_Noble_entropy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       const harm_aux_vars_struct *restrict harm_aux,

--- a/GRHayL/Con2Prim/utils_Palenzuela1D.h
+++ b/GRHayL/Con2Prim/utils_Palenzuela1D.h
@@ -59,7 +59,7 @@ ghl_error_codes_t ghl_tabulated_Palenzuela1D(
             double *restrict W_ptr),
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
       ghl_con2prim_diagnostics *restrict diagnostics);
@@ -75,7 +75,7 @@ ghl_error_codes_t ghl_hybrid_Palenzuela1D(
             double *restrict W_ptr),
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
       ghl_con2prim_diagnostics *restrict diagnostics);

--- a/GRHayL/GRHayL_Core/compute_ADM_auxiliaries.c
+++ b/GRHayL/GRHayL_Core/compute_ADM_auxiliaries.c
@@ -9,7 +9,7 @@
  * data and computes all the elements of the ghl_ADM_aux_quantities
  * struct.
  *
- * @param[in] ADM_metric pointer to a ghl_metric_quantities struct.
+ * @param[in] metric_adm pointer to a ghl_metric_quantities struct.
  *                         This contains the input ADM metric data.
  *
  * @param[out] metric_aux pointer to a ghl_ADM_aux_quantities struct.
@@ -17,39 +17,39 @@
  *
  */
 void ghl_compute_ADM_auxiliaries(
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       ghl_ADM_aux_quantities *restrict metric_aux) {
 
   double betaD[3];
-  ghl_raise_lower_vector_3D(ADM_metric->gammaDD, ADM_metric->betaU, betaD);
+  ghl_raise_lower_vector_3D(metric_adm->gammaDD, metric_adm->betaU, betaD);
 
-  const double shift2 = betaD[0]*ADM_metric->betaU[0]
-                      + betaD[1]*ADM_metric->betaU[1]
-                      + betaD[2]*ADM_metric->betaU[2];
+  const double shift2 = betaD[0]*metric_adm->betaU[0]
+                      + betaD[1]*metric_adm->betaU[1]
+                      + betaD[2]*metric_adm->betaU[2];
 
-  const double shift_over_lapse2[3] = {ADM_metric->betaU[0]*ADM_metric->lapseinv2,
-                                       ADM_metric->betaU[1]*ADM_metric->lapseinv2,
-                                       ADM_metric->betaU[2]*ADM_metric->lapseinv2};
+  const double shift_over_lapse2[3] = {metric_adm->betaU[0]*metric_adm->lapseinv2,
+                                       metric_adm->betaU[1]*metric_adm->lapseinv2,
+                                       metric_adm->betaU[2]*metric_adm->lapseinv2};
 
-  metric_aux->g4DD[0][0]                          = -SQR(ADM_metric->lapse) + shift2;
+  metric_aux->g4DD[0][0]                          = -SQR(metric_adm->lapse) + shift2;
   metric_aux->g4DD[0][1] = metric_aux->g4DD[1][0] = betaD[0];
   metric_aux->g4DD[0][2] = metric_aux->g4DD[2][0] = betaD[1];
   metric_aux->g4DD[0][3] = metric_aux->g4DD[3][0] = betaD[2];
-  metric_aux->g4DD[1][1]                          = ADM_metric->gammaDD[0][0];
-  metric_aux->g4DD[1][2] = metric_aux->g4DD[2][1] = ADM_metric->gammaDD[0][1];
-  metric_aux->g4DD[1][3] = metric_aux->g4DD[3][1] = ADM_metric->gammaDD[0][2];
-  metric_aux->g4DD[2][2]                          = ADM_metric->gammaDD[1][1];
-  metric_aux->g4DD[2][3] = metric_aux->g4DD[3][2] = ADM_metric->gammaDD[1][2];
-  metric_aux->g4DD[3][3]                          = ADM_metric->gammaDD[2][2];
+  metric_aux->g4DD[1][1]                          = metric_adm->gammaDD[0][0];
+  metric_aux->g4DD[1][2] = metric_aux->g4DD[2][1] = metric_adm->gammaDD[0][1];
+  metric_aux->g4DD[1][3] = metric_aux->g4DD[3][1] = metric_adm->gammaDD[0][2];
+  metric_aux->g4DD[2][2]                          = metric_adm->gammaDD[1][1];
+  metric_aux->g4DD[2][3] = metric_aux->g4DD[3][2] = metric_adm->gammaDD[1][2];
+  metric_aux->g4DD[3][3]                          = metric_adm->gammaDD[2][2];
 
-  metric_aux->g4UU[0][0]                          = -ADM_metric->lapseinv2;
+  metric_aux->g4UU[0][0]                          = -metric_adm->lapseinv2;
   metric_aux->g4UU[0][1] = metric_aux->g4UU[1][0] = shift_over_lapse2[0];
   metric_aux->g4UU[0][2] = metric_aux->g4UU[2][0] = shift_over_lapse2[1];
   metric_aux->g4UU[0][3] = metric_aux->g4UU[3][0] = shift_over_lapse2[2];
-  metric_aux->g4UU[1][1]                          = ADM_metric->gammaUU[0][0] - ADM_metric->betaU[0]*shift_over_lapse2[0];
-  metric_aux->g4UU[1][2] = metric_aux->g4UU[2][1] = ADM_metric->gammaUU[0][1] - ADM_metric->betaU[0]*shift_over_lapse2[1];
-  metric_aux->g4UU[1][3] = metric_aux->g4UU[3][1] = ADM_metric->gammaUU[0][2] - ADM_metric->betaU[0]*shift_over_lapse2[2];
-  metric_aux->g4UU[2][2]                          = ADM_metric->gammaUU[1][1] - ADM_metric->betaU[1]*shift_over_lapse2[1];
-  metric_aux->g4UU[2][3] = metric_aux->g4UU[3][2] = ADM_metric->gammaUU[1][2] - ADM_metric->betaU[1]*shift_over_lapse2[2];
-  metric_aux->g4UU[3][3]                          = ADM_metric->gammaUU[2][2] - ADM_metric->betaU[2]*shift_over_lapse2[2];
+  metric_aux->g4UU[1][1]                          = metric_adm->gammaUU[0][0] - metric_adm->betaU[0]*shift_over_lapse2[0];
+  metric_aux->g4UU[1][2] = metric_aux->g4UU[2][1] = metric_adm->gammaUU[0][1] - metric_adm->betaU[0]*shift_over_lapse2[1];
+  metric_aux->g4UU[1][3] = metric_aux->g4UU[3][1] = metric_adm->gammaUU[0][2] - metric_adm->betaU[0]*shift_over_lapse2[2];
+  metric_aux->g4UU[2][2]                          = metric_adm->gammaUU[1][1] - metric_adm->betaU[1]*shift_over_lapse2[1];
+  metric_aux->g4UU[2][3] = metric_aux->g4UU[3][2] = metric_adm->gammaUU[1][2] - metric_adm->betaU[1]*shift_over_lapse2[2];
+  metric_aux->g4UU[3][3]                          = metric_adm->gammaUU[2][2] - metric_adm->betaU[2]*shift_over_lapse2[2];
 }

--- a/GRHayL/GRHayL_Core/compute_TDNmunu.c
+++ b/GRHayL/GRHayL_Core/compute_TDNmunu.c
@@ -15,7 +15,7 @@
  * \f]
  * and \f$ b \f$ is computed using @ref ghl_compute_smallb_and_b2.
  *
- * @param[in] ADM_metric pointer to a ghl_metric_quantities struct containing the ADM metric
+ * @param[in] metric_adm pointer to a ghl_metric_quantities struct containing the ADM metric
  *
  * @param[in] metric_aux pointer to a ghl_ADM_aux_quantities struct
  *
@@ -27,7 +27,7 @@
  *
  */
 void ghl_compute_TDNmunu(
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_primitive_quantities *restrict prims,
       ghl_stress_energy *restrict Tmunu) {
@@ -50,7 +50,7 @@ void ghl_compute_TDNmunu(
   /***************************************************************/
   // Compute b^{\mu} and b^2
   double smallb[4], smallb2;
-  ghl_compute_smallb_and_b2(ADM_metric, prims, uD, smallb, &smallb2);
+  ghl_compute_smallb_and_b2(metric_adm, prims, uD, smallb, &smallb2);
 
   // Precompute some useful quantities, for later:
   const double rho0_h_plus_b2 = prims->rho*h_enthalpy + smallb2;

--- a/GRHayL/GRHayL_Core/compute_TUPmunu.c
+++ b/GRHayL/GRHayL_Core/compute_TUPmunu.c
@@ -15,7 +15,7 @@
  * \f]
  * and \f$ b \f$ is computed using @ref ghl_compute_smallb_and_b2.
  *
- * @param[in] ADM_metric pointer to a ghl_metric_quantities struct containing the ADM metric
+ * @param[in] metric_adm pointer to a ghl_metric_quantities struct containing the ADM metric
  *
  * @param[in] metric_aux pointer to a ghl_ADM_aux_quantities struct
  *
@@ -27,7 +27,7 @@
  *
  */
 void ghl_compute_TUPmunu(
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_primitive_quantities *restrict prims,
       ghl_stress_energy *restrict Tmunu) {
@@ -50,7 +50,7 @@ void ghl_compute_TUPmunu(
   /***************************************************************/
   // Compute b^{\mu} and b^2
   double smallb[4], smallb2;
-  ghl_compute_smallb_and_b2(ADM_metric, prims, uD, smallb, &smallb2);
+  ghl_compute_smallb_and_b2(metric_adm, prims, uD, smallb, &smallb2);
 
   // Precompute some useful quantities, for later:
   const double rho0_h_plus_b2 = (prims->rho*h_enthalpy + smallb2);

--- a/GRHayL/GRHayL_Core/compute_smallb_and_b2.c
+++ b/GRHayL/GRHayL_Core/compute_smallb_and_b2.c
@@ -39,7 +39,7 @@
  * \end{aligned}
  * \f]
  *
- * @param[in] ADM_metric pointer to a ghl_metric_quantities struct containing the ADM metric
+ * @param[in] metric_adm pointer to a ghl_metric_quantities struct containing the ADM metric
  *
  * @param[in] prims pointer to a ghl_primitive_quantities struct. Note that
  *                  ghl_primitive_quantities::u0 **must** be valid for this function.
@@ -52,13 +52,13 @@
  *
  */
 void ghl_compute_smallb_and_b2(
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_primitive_quantities *restrict prims,
       const double uDN[4],
       double smallb[4],
       double *restrict smallb2) {
 
-  const double one_over_W = ADM_metric->lapseinv/prims->u0;
+  const double one_over_W = metric_adm->lapseinv/prims->u0;
 
   /*
      Compute b^t (Eqs. 23 and 31 in http://arxiv.org/pdf/astro-ph/0503420.pdf):
@@ -66,7 +66,7 @@ void ghl_compute_smallb_and_b2(
      Note that our B = B/sqrt(4pi) of the paper's B. Then,
        b^t = u_i B^i/alpha
   */
-  smallb[0] = (uDN[1]*prims->BU[0] + uDN[2]*prims->BU[1] + uDN[3]*prims->BU[2])*ADM_metric->lapseinv;
+  smallb[0] = (uDN[1]*prims->BU[0] + uDN[2]*prims->BU[1] + uDN[3]*prims->BU[2])*metric_adm->lapseinv;
 
   /*
      Eq. 24 in http://arxiv.org/pdf/astro-ph/0503420.pdf
@@ -93,9 +93,9 @@ void ghl_compute_smallb_and_b2(
   //     = - (alpha b^t)^2 + gamma_{ij} ((b^t)^2 beta^i beta^j + b^i b^j + 2 b^t beta^j b^i)
   //     = - (alpha b^t)^2 + gamma_{ij} ((b^t)^2 beta^i beta^j + 2 b^t beta^j b^i + b^i b^j)
   //     = - (alpha b^t)^2 + gamma_{ij} (b^i + b^t beta^i) (b^j + b^t beta^j)
-  const double bi_plus_bt_betai[3] = {smallb[1] + smallb[0]*ADM_metric->betaU[0],
-                                      smallb[2] + smallb[0]*ADM_metric->betaU[1],
-                                      smallb[3] + smallb[0]*ADM_metric->betaU[2]};
+  const double bi_plus_bt_betai[3] = {smallb[1] + smallb[0]*metric_adm->betaU[0],
+                                      smallb[2] + smallb[0]*metric_adm->betaU[1],
+                                      smallb[3] + smallb[0]*metric_adm->betaU[2]};
 
-  *smallb2 = -SQR(ADM_metric->lapse*smallb[0]) + ghl_compute_vec2_from_vec3D(ADM_metric->gammaDD, bi_plus_bt_betai);
+  *smallb2 = -SQR(metric_adm->lapse*smallb[0]) + ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, bi_plus_bt_betai);
 }

--- a/GRHayL/GRHayL_Core/enforce_detgij_and_initialize_ADM_metric.c
+++ b/GRHayL/GRHayL_Core/enforce_detgij_and_initialize_ADM_metric.c
@@ -18,7 +18,7 @@
  *
  * @param[in] gxx,gxy,gxz,gyy,gyz,gzz components of the 3-metric \f$ g_{i j} \f$
  *
- * @param[out] ADM_metric pointer to ghl_metric_quantities struct
+ * @param[out] metric_adm pointer to ghl_metric_quantities struct
  *
  */
 void ghl_enforce_detgtij_and_initialize_ADM_metric(
@@ -32,17 +32,17 @@ void ghl_enforce_detgtij_and_initialize_ADM_metric(
       const double gyy,
       const double gyz,
       const double gzz,
-      ghl_metric_quantities *restrict ADM_metric) {
+      ghl_metric_quantities *restrict metric_adm) {
 
   ghl_initialize_metric(
         lapse, betax, betay, betaz,
         gxx, gxy, gxz,
         gyy, gyz, gzz,
-        ADM_metric);
+        metric_adm);
 
   ghl_ADM_aux_quantities metric_aux;
-  ghl_compute_ADM_auxiliaries(ADM_metric, &metric_aux);
-  const double phi = (1.0/12.0) * log(ADM_metric->detgamma);
+  ghl_compute_ADM_auxiliaries(metric_adm, &metric_aux);
+  const double phi = (1.0/12.0) * log(metric_adm->detgamma);
 
   const double psi2 = exp(2.0*phi);
   const double psi4 = SQR(psi2);
@@ -83,10 +83,10 @@ void ghl_enforce_detgtij_and_initialize_ADM_metric(
                     betax, betay, betaz,
                     gxx_new, gxy_new, gxz_new,
                     gyy_new, gyz_new, gzz_new,
-                    ADM_metric);
+                    metric_adm);
 
   if(gtijdet<0.0) ghl_warn(
                       "WARNING: det[3-metric]<0.0. Hopefully this is occurring in gz's! "
                       "gtij_phys = %.2e %.2e %.2e %.2e %.2e %.2e gtij_new = %.2e %.2e %.2e %.2e %.2e %.2e | gijdet = %.2e | gtijdet = %.2e\n",
-  			     gxx, gxy, gxz, gyy, gyz, gzz, gtxx, gtxy, gtxz, gtyy, gtyz, gtzz, ADM_metric->detgamma, gtijdet);
+  			     gxx, gxy, gxz, gyy, gyz, gzz, gtxx, gtxy, gtxz, gtyy, gtyz, gtzz, metric_adm->detgamma, gtijdet);
 }

--- a/GRHayL/GRHayL_Core/initialize_eos.c
+++ b/GRHayL/GRHayL_Core/initialize_eos.c
@@ -11,7 +11,7 @@
 ghl_error_codes_t (*ghl_con2prim_multi_method)(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prim,

--- a/GRHayL/GRHayL_Core/limit_v_and_compute_u0.c
+++ b/GRHayL/GRHayL_Core/limit_v_and_compute_u0.c
@@ -8,7 +8,7 @@
 
 ghl_error_codes_t ghl_limit_v_and_compute_u0(
       const ghl_parameters *restrict params,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       ghl_primitive_quantities *restrict prims,
       bool *restrict speed_limited) {
 
@@ -18,16 +18,16 @@ ghl_error_codes_t ghl_limit_v_and_compute_u0(
   //   = 1/(u^0 \alpha)^2 u_j u_l \gamma^{jl}  <- Since \gamma_{ij} \gamma^{ik} = \delta^k_j
   //   = 1/(u^0 \alpha)^2 ( (u^0 \alpha)^2 - 1 ) <- Using Eq. 56 of arXiv:astro-ph/0503420
   //   = 1 - 1/(u^0 \alpha)^2 <= 1
-  const double utU[3] = {prims->vU[0] + ADM_metric->betaU[0], prims->vU[1] + ADM_metric->betaU[1], prims->vU[2] + ADM_metric->betaU[2]};
-  double one_minus_one_over_alpha_u0_squared = ghl_compute_vec2_from_vec3D(ADM_metric->gammaDD, utU)*ADM_metric->lapseinv2;
+  const double utU[3] = {prims->vU[0] + metric_adm->betaU[0], prims->vU[1] + metric_adm->betaU[1], prims->vU[2] + metric_adm->betaU[2]};
+  double one_minus_one_over_alpha_u0_squared = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, utU)*metric_adm->lapseinv2;
 
   /*** Limit velocity to GAMMA_SPEED_LIMIT ***/
   const double one_minus_one_over_W_max_squared = 1.0 - params->inv_sq_max_Lorentz_factor; // 1 - W_max^{-2}
   if(one_minus_one_over_alpha_u0_squared > one_minus_one_over_W_max_squared) {
     const double correction_fac = sqrt(one_minus_one_over_W_max_squared/one_minus_one_over_alpha_u0_squared);
-    prims->vU[0] = utU[0]*correction_fac - ADM_metric->betaU[0];
-    prims->vU[1] = utU[1]*correction_fac - ADM_metric->betaU[1];
-    prims->vU[2] = utU[2]*correction_fac - ADM_metric->betaU[2];
+    prims->vU[0] = utU[0]*correction_fac - metric_adm->betaU[0];
+    prims->vU[1] = utU[1]*correction_fac - metric_adm->betaU[1];
+    prims->vU[2] = utU[2]*correction_fac - metric_adm->betaU[2];
     one_minus_one_over_alpha_u0_squared = one_minus_one_over_W_max_squared;
     *speed_limited |= true;
   }
@@ -37,7 +37,7 @@ ghl_error_codes_t ghl_limit_v_and_compute_u0(
   //double alpha_u0_minus_one = 1.0/sqrt(1.0-one_minus_one_over_alpha_u0_squared)-1.0;
   //u0_out          = (alpha_u0_minus_one + 1.0)*lapseinv;
   const double alpha_u0 = 1.0/sqrt(1.0-one_minus_one_over_alpha_u0_squared);
-  prims->u0 = alpha_u0*ADM_metric->lapseinv;
+  prims->u0 = alpha_u0*metric_adm->lapseinv;
   if(isnan(prims->u0))
     return ghl_error_u0_singular;
 

--- a/GRHayL/include/ghl.h
+++ b/GRHayL/include/ghl.h
@@ -442,7 +442,7 @@ void ghl_initialize_metric(
       ghl_metric_quantities *restrict metric);
 
 void ghl_compute_ADM_auxiliaries(
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       ghl_ADM_aux_quantities *restrict metric_aux);
 
 void ghl_enforce_detgtij_and_initialize_ADM_metric(
@@ -456,7 +456,7 @@ void ghl_enforce_detgtij_and_initialize_ADM_metric(
       const double gyy,
       const double gyz,
       const double gzz,
-      ghl_metric_quantities *restrict ADM_metric);
+      ghl_metric_quantities *restrict metric_adm);
 
 void ghl_initialize_extrinsic_curvature(
       const double Kxx,
@@ -495,31 +495,31 @@ void ghl_return_stress_energy(
 
 ghl_error_codes_t ghl_limit_v_and_compute_u0(
       const ghl_parameters *restrict params,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       ghl_primitive_quantities *restrict prims,
       bool *restrict speed_limited);
 
 void ghl_compute_TDNmunu(
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_primitive_quantities *restrict prims,
       ghl_stress_energy *restrict Tmunu);
 
 void ghl_compute_TUPmunu(
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_primitive_quantities *restrict prims,
       ghl_stress_energy *restrict Tmunu);
 
 void ghl_compute_smallb_and_b2(
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_primitive_quantities *restrict prims,
       const double uDN[4],
       double smallb[4],
       double *restrict smallb2);
 
 void ghl_compute_SU_Bsq_Ssq_BdotS(
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_conservative_quantities *restrict cons_undens,
       const ghl_primitive_quantities *restrict prims,
       double *restrict SU,

--- a/GRHayL/include/ghl_con2prim.h
+++ b/GRHayL/include/ghl_con2prim.h
@@ -47,7 +47,7 @@ void ghl_initialize_diagnostics(ghl_con2prim_diagnostics *restrict diagnostics);
 void ghl_apply_conservative_limits(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_primitive_quantities *restrict prims,
       ghl_conservative_quantities *restrict cons,
       ghl_con2prim_diagnostics *restrict diagnostics);
@@ -59,26 +59,26 @@ void ghl_undensitize_conservatives(
 
 void ghl_guess_primitives(
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prims);
 
 ghl_error_codes_t ghl_enforce_primitive_limits_and_compute_u0(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       ghl_primitive_quantities *restrict prims,
       bool *restrict speed_limited);
 
 void ghl_compute_conservs_and_Tmunu(
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_primitive_quantities *restrict prims,
       ghl_conservative_quantities *restrict cons,
       ghl_stress_energy *restrict Tmunu);
 
 void ghl_compute_conservs(
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_primitive_quantities *restrict prims,
       ghl_conservative_quantities *restrict cons);
@@ -88,7 +88,7 @@ void ghl_compute_conservs(
 ghl_error_codes_t ghl_con2prim_hybrid_multi_method(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prim,
@@ -97,7 +97,7 @@ ghl_error_codes_t ghl_con2prim_hybrid_multi_method(
 ghl_error_codes_t ghl_con2prim_tabulated_multi_method(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prim,
@@ -107,7 +107,7 @@ ghl_error_codes_t ghl_con2prim_hybrid_select_method(
       const ghl_con2prim_id_t c2p_key,
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prims,
@@ -117,7 +117,7 @@ ghl_error_codes_t ghl_con2prim_tabulated_select_method(
       const ghl_con2prim_id_t c2p_key,
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prims,
@@ -126,7 +126,7 @@ ghl_error_codes_t ghl_con2prim_tabulated_select_method(
 ghl_error_codes_t ghl_hybrid_Noble2D(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prim,
@@ -135,7 +135,7 @@ ghl_error_codes_t ghl_hybrid_Noble2D(
 ghl_error_codes_t ghl_hybrid_Noble1D(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -144,7 +144,7 @@ ghl_error_codes_t ghl_hybrid_Noble1D(
 ghl_error_codes_t ghl_hybrid_Noble1D_entropy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -153,7 +153,7 @@ ghl_error_codes_t ghl_hybrid_Noble1D_entropy(
 ghl_error_codes_t ghl_hybrid_Noble1D_entropy2(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -162,7 +162,7 @@ ghl_error_codes_t ghl_hybrid_Noble1D_entropy2(
 ghl_error_codes_t ghl_hybrid_Palenzuela1D_energy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prim,
@@ -171,7 +171,7 @@ ghl_error_codes_t ghl_hybrid_Palenzuela1D_energy(
 ghl_error_codes_t ghl_hybrid_Palenzuela1D_entropy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prim,
@@ -180,7 +180,7 @@ ghl_error_codes_t ghl_hybrid_Palenzuela1D_entropy(
 ghl_error_codes_t ghl_hybrid_Font1D(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims,
@@ -189,7 +189,7 @@ ghl_error_codes_t ghl_hybrid_Font1D(
 ghl_error_codes_t ghl_tabulated_Palenzuela1D_energy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prim,
@@ -198,7 +198,7 @@ ghl_error_codes_t ghl_tabulated_Palenzuela1D_energy(
 ghl_error_codes_t ghl_tabulated_Palenzuela1D_entropy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prim,
@@ -207,7 +207,7 @@ ghl_error_codes_t ghl_tabulated_Palenzuela1D_entropy(
 ghl_error_codes_t ghl_tabulated_Newman1D_energy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prim,
@@ -216,7 +216,7 @@ ghl_error_codes_t ghl_tabulated_Newman1D_energy(
 ghl_error_codes_t ghl_tabulated_Newman1D_entropy(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prim,
@@ -233,7 +233,7 @@ bool ghl_limit_utilde_and_compute_v(
 extern ghl_error_codes_t (*ghl_con2prim_multi_method)(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric,
+      const ghl_metric_quantities *restrict metric_adm,
       const ghl_ADM_aux_quantities *restrict metric_aux,
       const ghl_conservative_quantities *restrict cons,
       ghl_primitive_quantities *restrict prim,

--- a/GRHayL/include/ghl_eos_functions.h
+++ b/GRHayL/include/ghl_eos_functions.h
@@ -271,7 +271,7 @@ extern void (*ghl_calculate_HLLE_fluxes_dirn0)(
       const ghl_primitive_quantities *restrict prims_r,
       const ghl_primitive_quantities *restrict prims_l,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric_face,
+      const ghl_metric_quantities *restrict metric_adm_face,
       const double cmin,
       const double cmax,
       ghl_conservative_quantities *restrict cons_fluxes);
@@ -280,7 +280,7 @@ extern void (*ghl_calculate_HLLE_fluxes_dirn1)(
       const ghl_primitive_quantities *restrict prims_r,
       const ghl_primitive_quantities *restrict prims_l,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric_face,
+      const ghl_metric_quantities *restrict metric_adm_face,
       const double cmin,
       const double cmax,
       ghl_conservative_quantities *restrict cons_fluxes);
@@ -289,7 +289,7 @@ extern void (*ghl_calculate_HLLE_fluxes_dirn2)(
       const ghl_primitive_quantities *restrict prims_r,
       const ghl_primitive_quantities *restrict prims_l,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric_face,
+      const ghl_metric_quantities *restrict metric_adm_face,
       const double cmin,
       const double cmax,
       ghl_conservative_quantities *restrict cons_fluxes);

--- a/GRHayL/include/ghl_eos_functions_declaration.h
+++ b/GRHayL/include/ghl_eos_functions_declaration.h
@@ -270,7 +270,7 @@ void (*ghl_calculate_HLLE_fluxes_dirn0)(
       const ghl_primitive_quantities *restrict prims_r,
       const ghl_primitive_quantities *restrict prims_l,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric_face,
+      const ghl_metric_quantities *restrict metric_adm_face,
       const double cmin,
       const double cmax,
       ghl_conservative_quantities *restrict cons_fluxes);
@@ -279,7 +279,7 @@ void (*ghl_calculate_HLLE_fluxes_dirn1)(
       const ghl_primitive_quantities *restrict prims_r,
       const ghl_primitive_quantities *restrict prims_l,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric_face,
+      const ghl_metric_quantities *restrict metric_adm_face,
       const double cmin,
       const double cmax,
       ghl_conservative_quantities *restrict cons_fluxes);
@@ -288,7 +288,7 @@ void (*ghl_calculate_HLLE_fluxes_dirn2)(
       const ghl_primitive_quantities *restrict prims_r,
       const ghl_primitive_quantities *restrict prims_l,
       const ghl_eos_parameters *restrict eos,
-      const ghl_metric_quantities *restrict ADM_metric_face,
+      const ghl_metric_quantities *restrict metric_adm_face,
       const double cmin,
       const double cmax,
       ghl_conservative_quantities *restrict cons_fluxes);

--- a/Unit_Tests/data_gen/unit_test_data_ET_Legacy_conservs.c
+++ b/Unit_Tests/data_gen/unit_test_data_ET_Legacy_conservs.c
@@ -118,7 +118,7 @@ int main(int argc, char **argv) {
 
       eps[index] = eps_cold + (press[index]-P_cold)/(eos.Gamma_th-1.0)/rho_b[index];
 
-      ghl_metric_quantities ADM_metric;
+      ghl_metric_quantities metric_adm;
       ghl_primitive_quantities prims;
       ghl_conservative_quantities cons;
       ghl_stress_energy Tmunu;
@@ -127,10 +127,10 @@ int main(int argc, char **argv) {
             lapse[index], betax[index], betay[index], betaz[index],
             gxx[index], gxy[index], gxz[index],
             gyy[index], gyz[index], gzz[index],
-            &ADM_metric);
+            &metric_adm);
 
       ghl_ADM_aux_quantities metric_aux;
-      ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+      ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
       ghl_initialize_primitives(
             rho_b[index], press[index], eps[index],
@@ -141,11 +141,11 @@ int main(int argc, char **argv) {
 
       bool speed_limit;
       ghl_error_codes_t error = ghl_limit_v_and_compute_u0(
-            &params, &ADM_metric, &prims, &speed_limit);
+            &params, &metric_adm, &prims, &speed_limit);
       ghl_abort_if_error(error);
 
       // Compute conservatives based on these primitives
-      ghl_compute_conservs_and_Tmunu(&ADM_metric, &metric_aux, &prims, &cons, &Tmunu);
+      ghl_compute_conservs_and_Tmunu(&metric_adm, &metric_aux, &prims, &cons, &Tmunu);
 
       double dummy1, dummy2, dummy3;
       ghl_return_primitives(

--- a/Unit_Tests/data_gen/unit_test_data_ET_Legacy_induction_gauge_rhs.c
+++ b/Unit_Tests/data_gen/unit_test_data_ET_Legacy_induction_gauge_rhs.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
       for(int i=0; i<dirlength; i++) {
         const int index = indexf(dirlength,i,j,k);
 
-        ghl_metric_quantities ADM_metric;
+        ghl_metric_quantities metric_adm;
         double agxx, agxy, agxz, agyy, agyz, agzz;
         ghl_randomize_metric(
               &lapse[index], &betax[index], &betay[index], &betaz[index],
@@ -71,23 +71,23 @@ int main(int argc, char **argv) {
         ghl_initialize_metric(
               lapse[index], betax[index], betay[index], betaz[index],
               agxx, agxy, agxz, agyy, agyz, agzz,
-              &ADM_metric);
+              &metric_adm);
 
         ghl_ADM_aux_quantities metric_aux;
-        ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+        ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
-        const double phi = (1.0/12.0) * log(ADM_metric.detgamma);
+        const double phi = (1.0/12.0) * log(metric_adm.detgamma);
 
         const double psi2 = exp(2.0*phi);
         const double psi4 = SQR(psi2);
 
         psi[index]   = sqrt(psi2);
-        gupxx[index] = psi4*ADM_metric.gammaUU[0][0];
-        gupxy[index] = psi4*ADM_metric.gammaUU[0][1];
-        gupxz[index] = psi4*ADM_metric.gammaUU[0][2];
-        gupyy[index] = psi4*ADM_metric.gammaUU[1][1];
-        gupyz[index] = psi4*ADM_metric.gammaUU[1][2];
-        gupzz[index] = psi4*ADM_metric.gammaUU[2][2];
+        gupxx[index] = psi4*metric_adm.gammaUU[0][0];
+        gupxy[index] = psi4*metric_adm.gammaUU[0][1];
+        gupxz[index] = psi4*metric_adm.gammaUU[0][2];
+        gupyy[index] = psi4*metric_adm.gammaUU[1][1];
+        gupyz[index] = psi4*metric_adm.gammaUU[1][2];
+        gupzz[index] = psi4*metric_adm.gammaUU[2][2];
 
         const int x = abs(i-gauss_center)*dX[0];
         const int y = abs(j-gauss_center)*dX[1];

--- a/Unit_Tests/data_gen/unit_test_data_ET_Legacy_primitives.c
+++ b/Unit_Tests/data_gen/unit_test_data_ET_Legacy_primitives.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
 
       ghl_con2prim_diagnostics diagnostics;
       ghl_initialize_diagnostics(&diagnostics);
-      ghl_metric_quantities ADM_metric;
+      ghl_metric_quantities metric_adm;
       ghl_primitive_quantities prims;
       ghl_conservative_quantities cons;
       ghl_stress_energy Tmunu;
@@ -125,10 +125,10 @@ int main(int argc, char **argv) {
             lapse[index], betax[index], betay[index], betaz[index],
             gxx[index], gxy[index], gxz[index],
             gyy[index], gyz[index], gzz[index],
-            &ADM_metric);
+            &metric_adm);
 
       ghl_ADM_aux_quantities metric_aux;
-      ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+      ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
       ghl_initialize_primitives(
             rho_b[index], press[index], poison,
@@ -142,12 +142,12 @@ int main(int argc, char **argv) {
       prims.eps = eps_cold + (prims.press-P_cold)/(eos.Gamma_th-1.0)/prims.rho;
 
       ghl_error_codes_t error = ghl_limit_v_and_compute_u0(
-            &params, &ADM_metric, &prims, &diagnostics.speed_limited);
+            &params, &metric_adm, &prims, &diagnostics.speed_limited);
       ghl_abort_if_error(error);
 
       // Compute conservatives based on these primitives
       ghl_compute_conservs_and_Tmunu(
-            &ADM_metric, &metric_aux, &prims, &cons, &Tmunu);
+            &metric_adm, &metric_aux, &prims, &cons, &Tmunu);
 
       ghl_return_primitives(
             &prims, &rho_b[index], &press[index], &dummy,
@@ -171,14 +171,14 @@ int main(int argc, char **argv) {
   //   Subcase a) \tau fix 1 & 2, don't fix S
   //   Subcase b) Don't fix \tau, S fix 2
 
-  ghl_metric_quantities ADM_metric;
+  ghl_metric_quantities metric_adm;
   ghl_initialize_metric(
         1.0, 0.0, 0.0, 0.0,
         1.0, 0.0, 0.0,
         1.0, 0.0, 1.0,
-        &ADM_metric);
+        &metric_adm);
   ghl_ADM_aux_quantities metric_aux;
-  ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+  ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
   // Ouput data to files and generate perturbed data
   FILE* input = fopen_with_check("ET_Legacy_primitives_input.bin", "wb");

--- a/Unit_Tests/data_gen/unit_test_data_con2prim_multi_method_hybrid.c
+++ b/Unit_Tests/data_gen/unit_test_data_con2prim_multi_method_hybrid.c
@@ -187,7 +187,7 @@ int main(int argc, char **argv) {
       //WVU_EOS_P_and_eps_from_rho_Ye_T( xrho,xye,xtemp, &xpress,&xeps );
 
       // Define the various GRHayL structs for the unit tests
-      ghl_metric_quantities ADM_metric;
+      ghl_metric_quantities metric_adm;
       ghl_primitive_quantities prims;
       ghl_conservative_quantities cons;
 
@@ -209,10 +209,10 @@ int main(int argc, char **argv) {
           local_lapse, local_betax, local_betay, local_betaz,
           local_gxx, local_gxy, local_gxz,
           local_gyy, local_gyz, local_gzz,
-          &ADM_metric);
+          &metric_adm);
 
       ghl_ADM_aux_quantities metric_aux;
-      ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+      ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
       ghl_initialize_primitives(
             xrho, xpress, poison,
@@ -223,7 +223,7 @@ int main(int argc, char **argv) {
 
       bool speed_limited;
       ghl_error_codes_t error = ghl_limit_v_and_compute_u0(
-            &params, &ADM_metric, &prims, &speed_limited);
+            &params, &metric_adm, &prims, &speed_limited);
       ghl_abort_if_error(error);
 
       // We need epsilon to compute the enthalpy in ghl_compute_conservs_and_Tmunu;
@@ -232,19 +232,19 @@ int main(int argc, char **argv) {
       prims.entropy = ghl_hybrid_compute_entropy_function(&eos, prims.rho, prims.press);
 
       // Compute conservatives based on these primitives
-      ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
+      ghl_compute_conservs(&metric_adm, &metric_aux, &prims, &cons);
 
-      lapse[index] = ADM_metric.lapse;
-      betax[index] = ADM_metric.betaU[0];
-      betay[index] = ADM_metric.betaU[1];
-      betaz[index] = ADM_metric.betaU[2];
+      lapse[index] = metric_adm.lapse;
+      betax[index] = metric_adm.betaU[0];
+      betay[index] = metric_adm.betaU[1];
+      betaz[index] = metric_adm.betaU[2];
 
-      gxx[index] = ADM_metric.gammaDD[0][0];
-      gxy[index] = ADM_metric.gammaDD[0][1];
-      gxz[index] = ADM_metric.gammaDD[0][2];
-      gyy[index] = ADM_metric.gammaDD[1][1];
-      gyz[index] = ADM_metric.gammaDD[1][2];
-      gzz[index] = ADM_metric.gammaDD[2][2];
+      gxx[index] = metric_adm.gammaDD[0][0];
+      gxy[index] = metric_adm.gammaDD[0][1];
+      gxz[index] = metric_adm.gammaDD[0][2];
+      gyy[index] = metric_adm.gammaDD[1][1];
+      gyz[index] = metric_adm.gammaDD[1][2];
+      gzz[index] = metric_adm.gammaDD[2][2];
 
       ghl_return_primitives(&prims,
             &rho_b[index], &press[index], &eps[index],
@@ -415,7 +415,7 @@ int main(int argc, char **argv) {
 
       ghl_con2prim_diagnostics diagnostics;
       ghl_initialize_diagnostics(&diagnostics);
-      ghl_metric_quantities ADM_metric;
+      ghl_metric_quantities metric_adm;
       ghl_primitive_quantities prims;
       ghl_conservative_quantities cons;
 
@@ -423,10 +423,10 @@ int main(int argc, char **argv) {
             lapse[i], betax[i], betay[i], betaz[i],
             gxx[i], gxy[i], gxz[i],
             gyy[i], gyz[i], gzz[i],
-            &ADM_metric);
+            &metric_adm);
 
       ghl_ADM_aux_quantities metric_aux;
-      ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+      ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
       ghl_initialize_primitives(
             rho_b_orig[i], press_orig[i], eps_orig[i],
@@ -442,7 +442,7 @@ int main(int argc, char **argv) {
       if(i == arraylength-1 || i == arraylength-2)
         params.psi6threshold = 0.0;
       ghl_apply_conservative_limits(
-            &params, &eos, &ADM_metric,
+            &params, &eos, &metric_adm,
             &prims, &cons, &diagnostics);
       if(i == arraylength-1 || i == arraylength-2)
         params.psi6threshold = Psi6threshold;
@@ -486,7 +486,7 @@ int main(int argc, char **argv) {
       for(int i=0; i<arraylength; i++) {
         ghl_con2prim_diagnostics diagnostics;
         ghl_initialize_diagnostics(&diagnostics);
-        ghl_metric_quantities ADM_metric;
+        ghl_metric_quantities metric_adm;
         ghl_primitive_quantities prims;
         ghl_conservative_quantities cons, cons_undens;
 
@@ -494,10 +494,10 @@ int main(int argc, char **argv) {
               lapse[i], betax[i], betay[i], betaz[i],
               gxx[i], gxy[i], gxz[i],
               gyy[i], gyz[i], gzz[i],
-              &ADM_metric);
+              &metric_adm);
 
         ghl_ADM_aux_quantities metric_aux;
-        ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+        ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
         ghl_initialize_primitives(
               poison, poison, poison,
@@ -510,11 +510,11 @@ int main(int argc, char **argv) {
               S_x_orig[i], S_y_orig[i], S_z_orig[i],
               ent_star[i], poison, &cons);
 
-        ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
+        ghl_undensitize_conservatives(metric_adm.sqrt_detgamma, &cons, &cons_undens);
         if(params.calc_prim_guess)
-          ghl_guess_primitives(&eos, &ADM_metric, &cons, &prims);
+          ghl_guess_primitives(&eos, &metric_adm, &cons, &prims);
         c2p_check[i] = ghl_con2prim_hybrid_select_method(
-              methods[routine], &params, &eos, &ADM_metric, &metric_aux,
+              methods[routine], &params, &eos, &metric_adm, &metric_aux,
               &cons_undens, &prims, &diagnostics);
 
         ghl_return_primitives(
@@ -556,17 +556,17 @@ int main(int argc, char **argv) {
       S_z_orig[i] = S_z[i];
       ent_star_orig[i] = ent_star[i];
 
-      ghl_metric_quantities ADM_metric;
+      ghl_metric_quantities metric_adm;
       ghl_primitive_quantities prims;
 
       ghl_initialize_metric(
             lapse[i], betax[i], betay[i], betaz[i],
             gxx[i], gxy[i], gxz[i],
             gyy[i], gyz[i], gzz[i],
-            &ADM_metric);
+            &metric_adm);
 
       ghl_ADM_aux_quantities metric_aux;
-      ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+      ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
       ghl_initialize_primitives(
             rho_b_orig[i], press_orig[i], eps_orig[i],
@@ -576,7 +576,7 @@ int main(int argc, char **argv) {
 
       bool speed_limited;
       ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(
-            &params, &eos, &ADM_metric, &prims, &speed_limited);
+            &params, &eos, &metric_adm, &prims, &speed_limited);
       ghl_abort_if_error(error);
 
       ghl_return_primitives(
@@ -611,7 +611,7 @@ int main(int argc, char **argv) {
       S_z_orig[i] = S_z[i];
       ent_star_orig[i] = ent_star[i];
 
-      ghl_metric_quantities ADM_metric;
+      ghl_metric_quantities metric_adm;
       ghl_primitive_quantities prims;
       ghl_conservative_quantities cons;
       ghl_stress_energy Tmunu;
@@ -620,10 +620,10 @@ int main(int argc, char **argv) {
             lapse[i], betax[i], betay[i], betaz[i],
             gxx[i], gxy[i], gxz[i],
             gyy[i], gyz[i], gzz[i],
-            &ADM_metric);
+            &metric_adm);
 
       ghl_ADM_aux_quantities metric_aux;
-      ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+      ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
       ghl_initialize_primitives(
             rho_b_orig[i], press_orig[i], eps_orig[i],
@@ -633,7 +633,7 @@ int main(int argc, char **argv) {
       prims.u0 = u0[i];
 
       ghl_compute_conservs_and_Tmunu(
-            &ADM_metric, &metric_aux, &prims, &cons, &Tmunu);
+            &metric_adm, &metric_aux, &prims, &cons, &Tmunu);
 
       ghl_return_conservatives(
             &cons, &rho_star[i], &tau[i],

--- a/Unit_Tests/data_gen/unit_test_data_hybrid_flux.c
+++ b/Unit_Tests/data_gen/unit_test_data_hybrid_flux.c
@@ -109,13 +109,13 @@ int main(int argc, char **argv) {
           &vx_l[index], &vy_l[index], &vz_l[index],
           &Bx_l[index], &By_l[index], &Bz_l[index]);
 
-    ghl_metric_quantities ADM_metric;
+    ghl_metric_quantities metric_adm;
     ghl_initialize_metric(
           lapse[index],
           betax[index], betay[index], betaz[index],
           gxx[index], gxy[index], gxz[index],
           gyy[index], gyz[index], gzz[index],
-          &ADM_metric);
+          &metric_adm);
 
     ghl_primitive_quantities prims_r, prims_l;
     ghl_initialize_primitives(
@@ -134,10 +134,10 @@ int main(int argc, char **argv) {
 
     bool speed_limit;
     ghl_error_codes_t error = ghl_limit_v_and_compute_u0(
-          &params, &ADM_metric, &prims_r, &speed_limit);
+          &params, &metric_adm, &prims_r, &speed_limit);
     ghl_abort_if_error(error);
     error = ghl_limit_v_and_compute_u0(
-          &params, &ADM_metric, &prims_l, &speed_limit);
+          &params, &metric_adm, &prims_l, &speed_limit);
     ghl_abort_if_error(error);
 
     prims_r.entropy = ghl_hybrid_compute_entropy_function(&eos, prims_r.rho, prims_r.press);
@@ -145,13 +145,13 @@ int main(int argc, char **argv) {
 
     ghl_calculate_characteristic_speed_dirn0(
           &prims_r, &prims_l, &eos,
-          &ADM_metric, &cxmin[index], &cxmax[index]);
+          &metric_adm, &cxmin[index], &cxmax[index]);
     ghl_calculate_characteristic_speed_dirn1(
           &prims_r, &prims_l, &eos,
-          &ADM_metric, &cymin[index], &cymax[index]);
+          &metric_adm, &cymin[index], &cymax[index]);
     ghl_calculate_characteristic_speed_dirn2(
           &prims_r, &prims_l, &eos,
-          &ADM_metric, &czmin[index], &czmax[index]);
+          &metric_adm, &czmin[index], &czmax[index]);
   }
 
   double *cmin;
@@ -274,13 +274,13 @@ int main(int argc, char **argv) {
         }
 
         for(int index=0; index<arraylength; index++) {
-          ghl_metric_quantities ADM_metric;
+          ghl_metric_quantities metric_adm;
           ghl_initialize_metric(
                 lapse[index],
                 betax[index], betay[index], betaz[index],
                 gxx[index], gxy[index], gxz[index],
                 gyy[index], gyz[index], gzz[index],
-                &ADM_metric);
+                &metric_adm);
 
           ghl_primitive_quantities prims_r, prims_l;
           ghl_initialize_primitives(
@@ -299,10 +299,10 @@ int main(int argc, char **argv) {
 
           bool speed_limit;
           ghl_error_codes_t error = ghl_limit_v_and_compute_u0(
-                &params, &ADM_metric, &prims_r, &speed_limit);
+                &params, &metric_adm, &prims_r, &speed_limit);
           ghl_abort_if_error(error);
           error = ghl_limit_v_and_compute_u0(
-                &params, &ADM_metric, &prims_l, &speed_limit);
+                &params, &metric_adm, &prims_l, &speed_limit);
           ghl_abort_if_error(error);
 
           prims_r.entropy = ghl_hybrid_compute_entropy_function(&eos, prims_r.rho, prims_r.press);
@@ -311,7 +311,7 @@ int main(int argc, char **argv) {
           ghl_conservative_quantities cons_fluxes;
           calculate_HLLE_fluxes(
                 &prims_r, &prims_l, &eos,
-                &ADM_metric, cmin[index], cmax[index],
+                &metric_adm, cmin[index], cmax[index],
                 &cons_fluxes);
 
           rho_star_flux[index] = cons_fluxes.rho;

--- a/Unit_Tests/data_gen/unit_test_data_induction_interpolation.c
+++ b/Unit_Tests/data_gen/unit_test_data_induction_interpolation.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
       for(int i=0; i<dirlength; i++) {
         const int index = indexf(dirlength,i,j,k);
 
-        ghl_metric_quantities ADM_metric;
+        ghl_metric_quantities metric_adm;
         ghl_randomize_metric(
               &lapse[index], &betax[index], &betay[index], &betaz[index],
               &gxx[index], &gxy[index], &gxz[index],
@@ -71,23 +71,23 @@ int main(int argc, char **argv) {
               lapse[index], betax[index], betay[index], betaz[index],
               gxx[index], gxy[index], gxz[index],
               gyy[index], gyz[index], gzz[index],
-              &ADM_metric);
+              &metric_adm);
 
         ghl_ADM_aux_quantities metric_aux;
-        ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+        ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
-        const double phi = (1.0/12.0) * log(ADM_metric.detgamma);
+        const double phi = (1.0/12.0) * log(metric_adm.detgamma);
 
         const double psi2 = exp(2.0*phi);
         const double psi4 = SQR(psi2);
 
         psi[index]    = sqrt(psi2);
-        gtupxx[index] = psi4*ADM_metric.gammaUU[0][0];
-        gtupxy[index] = psi4*ADM_metric.gammaUU[0][1];
-        gtupxz[index] = psi4*ADM_metric.gammaUU[0][2];
-        gtupyy[index] = psi4*ADM_metric.gammaUU[1][1];
-        gtupyz[index] = psi4*ADM_metric.gammaUU[1][2];
-        gtupzz[index] = psi4*ADM_metric.gammaUU[2][2];
+        gtupxx[index] = psi4*metric_adm.gammaUU[0][0];
+        gtupxy[index] = psi4*metric_adm.gammaUU[0][1];
+        gtupxz[index] = psi4*metric_adm.gammaUU[0][2];
+        gtupyy[index] = psi4*metric_adm.gammaUU[1][1];
+        gtupyz[index] = psi4*metric_adm.gammaUU[1][2];
+        gtupzz[index] = psi4*metric_adm.gammaUU[2][2];
 
         const int x = abs(i-gauss_center)*dX[0];
         const int y = abs(j-gauss_center)*dX[1];

--- a/Unit_Tests/data_gen/unit_test_data_tabulated_flux.c
+++ b/Unit_Tests/data_gen/unit_test_data_tabulated_flux.c
@@ -133,13 +133,13 @@ int main(int argc, char **argv) {
           &vx_l[index], &vy_l[index], &vz_l[index],
           &Bx_l[index], &By_l[index], &Bz_l[index]);
 
-    ghl_metric_quantities ADM_metric;
+    ghl_metric_quantities metric_adm;
     ghl_initialize_metric(
           lapse[index],
           betax[index], betay[index], betaz[index],
           gxx[index], gxy[index], gxz[index],
           gyy[index], gyz[index], gzz[index],
-          &ADM_metric);
+          &metric_adm);
 
     ghl_primitive_quantities prims_r, prims_l;
     ghl_initialize_primitives(
@@ -166,23 +166,23 @@ int main(int argc, char **argv) {
 
     bool speed_limit;
     error = ghl_limit_v_and_compute_u0(
-          &params, &ADM_metric, &prims_r, &speed_limit);
+          &params, &metric_adm, &prims_r, &speed_limit);
     ghl_abort_if_error(error);
     error = ghl_limit_v_and_compute_u0(
-          &params, &ADM_metric, &prims_l, &speed_limit);
+          &params, &metric_adm, &prims_l, &speed_limit);
     ghl_abort_if_error(error);
 
     ghl_calculate_characteristic_speed_dirn0(
           &prims_r, &prims_l, &eos,
-          &ADM_metric, &cxmin[index], &cxmax[index]);
+          &metric_adm, &cxmin[index], &cxmax[index]);
 
     ghl_calculate_characteristic_speed_dirn1(
           &prims_r, &prims_l, &eos,
-          &ADM_metric, &cymin[index], &cymax[index]);
+          &metric_adm, &cymin[index], &cymax[index]);
 
     ghl_calculate_characteristic_speed_dirn2(
           &prims_r, &prims_l, &eos,
-          &ADM_metric, &czmin[index], &czmax[index]);
+          &metric_adm, &czmin[index], &czmax[index]);
   }
 
   char filename[100];
@@ -311,13 +311,13 @@ int main(int argc, char **argv) {
         }
 
         for(int index=0; index<arraylength; index++) {
-          ghl_metric_quantities ADM_metric;
+          ghl_metric_quantities metric_adm;
           ghl_initialize_metric(
                 lapse[index],
                 betax[index], betay[index], betaz[index],
                 gxx[index], gxy[index], gxz[index],
                 gyy[index], gyz[index], gzz[index],
-                &ADM_metric);
+                &metric_adm);
 
           ghl_primitive_quantities prims_r, prims_l;
           ghl_initialize_primitives(
@@ -344,16 +344,16 @@ int main(int argc, char **argv) {
 
           bool speed_limit;
           error = ghl_limit_v_and_compute_u0(
-                &params, &ADM_metric, &prims_r, &speed_limit);
+                &params, &metric_adm, &prims_r, &speed_limit);
           ghl_abort_if_error(error);
           error = ghl_limit_v_and_compute_u0(
-                &params, &ADM_metric, &prims_l, &speed_limit);
+                &params, &metric_adm, &prims_l, &speed_limit);
           ghl_abort_if_error(error);
 
           ghl_conservative_quantities cons_fluxes;
           calculate_HLLE_fluxes(
                 &prims_r, &prims_l, &eos,
-                &ADM_metric, cmin[index], cmax[index],
+                &metric_adm, cmin[index], cmax[index],
                 &cons_fluxes);
 
           rho_star_flux[index] = cons_fluxes.rho;

--- a/Unit_Tests/unit_test_ET_Legacy_conservs.c
+++ b/Unit_Tests/unit_test_ET_Legacy_conservs.c
@@ -236,7 +236,7 @@ int main(int argc, char **argv) {
     // Define the various GRHayL structs for the unit tests
     ghl_con2prim_diagnostics diagnostics;
     ghl_initialize_diagnostics(&diagnostics);
-    ghl_metric_quantities ADM_metric;
+    ghl_metric_quantities metric_adm;
     ghl_primitive_quantities prims;
     ghl_conservative_quantities cons;
     ghl_stress_energy Tmunu;
@@ -245,10 +245,10 @@ int main(int argc, char **argv) {
                       betax[index], betay[index], betaz[index],
                       gxx[index], gxy[index], gxz[index],
                       gyy[index], gyz[index], gzz[index],
-                      &ADM_metric);
+                      &metric_adm);
 
     ghl_ADM_aux_quantities metric_aux;
-    ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+    ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
     // B's get rescaled to match IGM's definition of B
     ghl_initialize_primitives(rho_b[index], press[index], eps[index],
@@ -262,9 +262,9 @@ int main(int argc, char **argv) {
                              poison, poison, &cons);
 
     // Enforce limits on primitive variables and recompute conservatives.
-    int error = ghl_enforce_primitive_limits_and_compute_u0(&params, &eos, &ADM_metric, &prims, &diagnostics.speed_limited);
+    int error = ghl_enforce_primitive_limits_and_compute_u0(&params, &eos, &metric_adm, &prims, &diagnostics.speed_limited);
     ghl_abort_if_error(error);
-    ghl_compute_conservs_and_Tmunu(&ADM_metric, &metric_aux, &prims, &cons, &Tmunu);
+    ghl_compute_conservs_and_Tmunu(&metric_adm, &metric_aux, &prims, &cons, &Tmunu);
 
     // Here, we call the ghl_return_* functions and then repack the struct from that data. These functions are too
     // small to need an individual test, and they are primarily used by Con2Prim anyways.

--- a/Unit_Tests/unit_test_ET_Legacy_primitives.c
+++ b/Unit_Tests/unit_test_ET_Legacy_primitives.c
@@ -160,7 +160,7 @@ int main(int argc, char **argv) {
     // Define the various GRHayL structs for the unit tests
     ghl_con2prim_diagnostics diagnostics;
     ghl_initialize_diagnostics(&diagnostics);
-    ghl_metric_quantities ADM_metric;
+    ghl_metric_quantities metric_adm;
     ghl_primitive_quantities prims;
     ghl_conservative_quantities cons, cons_undens;
 
@@ -168,10 +168,10 @@ int main(int argc, char **argv) {
                       betax[index], betay[index], betaz[index],
                       gxx[index], gxy[index], gxz[index],
                       gyy[index], gyz[index], gzz[index],
-                      &ADM_metric);
+                      &metric_adm);
 
     ghl_ADM_aux_quantities metric_aux;
-    ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+    ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
     // B's get rescaled to match IGM's definition of B
     ghl_initialize_primitives(
@@ -192,18 +192,18 @@ int main(int argc, char **argv) {
       if(eos.eos_type == ghl_eos_hybrid) { //Hybrid-only
         if(index == arraylength-2 || index == arraylength-1) {
           params.psi6threshold = 1e-1; // Artificially triggering fix
-          ghl_apply_conservative_limits(&params, &eos, &ADM_metric, &prims, &cons, &diagnostics);
+          ghl_apply_conservative_limits(&params, &eos, &metric_adm, &prims, &cons, &diagnostics);
           params.psi6threshold = Psi6threshold;
         } else {
-          ghl_apply_conservative_limits(&params, &eos, &ADM_metric, &prims, &cons, &diagnostics);
+          ghl_apply_conservative_limits(&params, &eos, &metric_adm, &prims, &cons, &diagnostics);
         }
       }
 
       // The Con2Prim routines require the undensitized variables, but IGM evolves the densitized variables.
-      ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
+      ghl_undensitize_conservatives(metric_adm.sqrt_detgamma, &cons, &cons_undens);
 
       /************* Conservative-to-primitive recovery ************/
-      check = ghl_con2prim_hybrid_multi_method(&params, &eos, &ADM_metric, &metric_aux, &cons_undens, &prims, &diagnostics);
+      check = ghl_con2prim_hybrid_multi_method(&params, &eos, &metric_adm, &metric_aux, &cons_undens, &prims, &diagnostics);
 
       if(check)
         printf("Con2Prim failed!");

--- a/Unit_Tests/unit_test_apply_conservative_limits.c
+++ b/Unit_Tests/unit_test_apply_conservative_limits.c
@@ -144,7 +144,7 @@ int main(int argc, char **argv) {
     // Define the various GRHayL structs for the unit tests
     ghl_con2prim_diagnostics diagnostics;
     ghl_initialize_diagnostics(&diagnostics);
-    ghl_metric_quantities ADM_metric;
+    ghl_metric_quantities metric_adm;
     ghl_primitive_quantities prims;
     ghl_conservative_quantities cons;
 
@@ -154,10 +154,10 @@ int main(int argc, char **argv) {
           betax[i], betay[i], betaz[i],
           gxx[i], gxy[i], gxz[i],
           gyy[i], gyz[i], gzz[i],
-          &ADM_metric);
+          &metric_adm);
 
     ghl_ADM_aux_quantities metric_aux;
-    ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+    ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
     ghl_initialize_primitives(
           poison, poison, poison,
@@ -174,7 +174,7 @@ int main(int argc, char **argv) {
     //This applies inequality fixes on the conservatives
     if(i == arraylength-1 || i == arraylength-2)
       params.psi6threshold = 0.0;
-    ghl_apply_conservative_limits(&params, &eos, &ADM_metric, &prims, &cons, &diagnostics);
+    ghl_apply_conservative_limits(&params, &eos, &metric_adm, &prims, &cons, &diagnostics);
     if(i == arraylength-1 || i == arraylength-2)
       params.psi6threshold = Psi6threshold;
 

--- a/Unit_Tests/unit_test_code_error.c
+++ b/Unit_Tests/unit_test_code_error.c
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
       break;
   }
 
-  ghl_metric_quantities ADM_metric;
+  ghl_metric_quantities metric_adm;
   ghl_primitive_quantities prims;
   ghl_conservative_quantities cons;
   ghl_con2prim_diagnostics diagnostics;
@@ -127,10 +127,10 @@ int main(int argc, char **argv) {
         1.0, 0.0, 0.0, 0.0,
         1.0, 0.0, 0.0,
         1.0, 0.0, 1.0,
-        &ADM_metric);
+        &metric_adm);
 
   ghl_ADM_aux_quantities metric_aux;
-  ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+  ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
   /*
      ghl_limit_v_and_compute_u0:
@@ -143,11 +143,11 @@ int main(int argc, char **argv) {
       prims.vU[0] = 0.0/0.0;
       prims.vU[1] = 0.0/0.0;
       prims.vU[2] = 0.0/0.0;
-      error = ghl_limit_v_and_compute_u0(&params, &ADM_metric, &prims, &speed_limited);
+      error = ghl_limit_v_and_compute_u0(&params, &metric_adm, &prims, &speed_limited);
       expect_error_code(error, test_key, "ghl_limit_v_and_compute_u0");
       break;
     case 5:
-      error = ghl_con2prim_hybrid_select_method(-5, &params, &hybrid_eos, &ADM_metric, &metric_aux, &cons, &prims, &diagnostics);
+      error = ghl_con2prim_hybrid_select_method(-5, &params, &hybrid_eos, &metric_adm, &metric_aux, &cons, &prims, &diagnostics);
       expect_error_code(error, test_key, "ghl_con2prim_hybrid_select_method");
       break;
   }
@@ -393,7 +393,7 @@ Y_e: 1.000000000000000e+00, 3.000000000000000e+00
 
   switch (test_key) {
     case 32:
-      error = ghl_con2prim_tabulated_select_method(-10, &params, &tab_eos, &ADM_metric, &metric_aux, &cons, &prims, &diagnostics);
+      error = ghl_con2prim_tabulated_select_method(-10, &params, &tab_eos, &metric_adm, &metric_aux, &cons, &prims, &diagnostics);
       expect_error_code(error, test_key, "ghl_con2prim_tabulated_select_method");
       break;
   }

--- a/Unit_Tests/unit_test_compute_conservs_and_Tmunu.c
+++ b/Unit_Tests/unit_test_compute_conservs_and_Tmunu.c
@@ -201,7 +201,7 @@ int main(int argc, char **argv) {
     // Define the various GRHayL structs for the unit tests
     ghl_con2prim_diagnostics diagnostics;
     ghl_initialize_diagnostics(&diagnostics);
-    ghl_metric_quantities ADM_metric;
+    ghl_metric_quantities metric_adm;
     ghl_primitive_quantities prims;
     ghl_conservative_quantities cons;
     ghl_stress_energy Tmunu;
@@ -212,10 +212,10 @@ int main(int argc, char **argv) {
           betax[i], betay[i], betaz[i],
           gxx[i], gxy[i], gxz[i],
           gyy[i], gyz[i], gzz[i],
-          &ADM_metric);
+          &metric_adm);
 
     ghl_ADM_aux_quantities metric_aux;
-    ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+    ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
     ghl_initialize_primitives(
           rho_b[i], press[i], eps[i],
@@ -226,7 +226,7 @@ int main(int argc, char **argv) {
     prims.u0 = u0[i];
 
     // This computes the conservatives and stress-energy tensor from the new primitives
-    ghl_compute_conservs_and_Tmunu(&ADM_metric, &metric_aux, &prims, &cons, &Tmunu);
+    ghl_compute_conservs_and_Tmunu(&metric_adm, &metric_aux, &prims, &cons, &Tmunu);
 
     ghl_conservative_quantities cons_trusted, cons_pert;
     ghl_stress_energy Tmunu_trusted, Tmunu_pert;
@@ -268,8 +268,8 @@ int main(int argc, char **argv) {
             requiring some sort of interpolation which the user handles separately.
        We can easily use this test to also check these functions.
     */
-    ghl_compute_conservs(&ADM_metric, &metric_aux, &prims, &cons);
-    ghl_compute_TDNmunu(&ADM_metric, &metric_aux, &prims, &Tmunu);
+    ghl_compute_conservs(&metric_adm, &metric_aux, &prims, &cons);
+    ghl_compute_TDNmunu(&metric_adm, &metric_aux, &prims, &Tmunu);
     ghl_pert_test_fail_conservatives(params.evolve_entropy, &cons_trusted, &cons, &cons_pert);
     ghl_pert_test_fail_stress_energy(&Tmunu_trusted, &Tmunu, &Tmunu_pert);
   }

--- a/Unit_Tests/unit_test_con2prim_debug.c
+++ b/Unit_Tests/unit_test_con2prim_debug.c
@@ -4,7 +4,7 @@
 
 void init_metric_from_string( const char *lapse_shift_string_in,
                               const char *metric_string_in,
-                              ghl_metric_quantities *ADM_metric ) {
+                              ghl_metric_quantities *metric_adm ) {
 
   char *token;
   char lapse_shift_string[strlen(lapse_shift_string_in)+1];
@@ -28,7 +28,7 @@ void init_metric_from_string( const char *lapse_shift_string_in,
 
   ghl_initialize_metric(lapse, betaU0, betaU1, betaU2,
                         gxx, gxy, gxz, gyy, gyz, gzz,
-                        ADM_metric);
+                        metric_adm);
 }
 
 void init_conservs_from_string( const char *conservs_string_in,
@@ -125,17 +125,17 @@ int main(int argc, char **argv) {
   const char *conservs_string    = "5.132187e-10 -2.636040e-05 2.826288e-06 2.442308e-06 1.950662e-06 -1.984531e+06 3.046700e-10";
   const char *B_string           = "-2.447595e-03 8.354818e-03 -4.903698e-03";
 
-  ghl_metric_quantities ADM_metric;
-  init_metric_from_string(lapse_shift_string, metric_string, &ADM_metric);
+  ghl_metric_quantities metric_adm;
+  init_metric_from_string(lapse_shift_string, metric_string, &metric_adm);
 
   ghl_ADM_aux_quantities metric_aux;
-  ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+  ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
   ghl_conservative_quantities cons;
   init_conservs_from_string(conservs_string, &cons);
 
   ghl_conservative_quantities cons_undens;
-  ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
+  ghl_undensitize_conservatives(metric_adm.sqrt_detgamma, &cons, &cons_undens);
 
   ghl_primitive_quantities prims;
   init_Bfield_from_string(B_string, &prims);
@@ -143,7 +143,7 @@ int main(int argc, char **argv) {
   ghl_con2prim_diagnostics diagnostics;
   ghl_initialize_diagnostics(&diagnostics);
 
-  int check = ghl_con2prim_tabulated_multi_method(&params, &eos, &ADM_metric, &metric_aux, &cons_undens, &prims, &diagnostics);
+  int check = ghl_con2prim_tabulated_multi_method(&params, &eos, &metric_adm, &metric_aux, &cons_undens, &prims, &diagnostics);
 
   ghl_debug_print_cons(&cons);
 

--- a/Unit_Tests/unit_test_con2prim_multi_method_hybrid.c
+++ b/Unit_Tests/unit_test_con2prim_multi_method_hybrid.c
@@ -187,7 +187,7 @@ int main(int argc, char **argv) {
       // Define the various GRHayL structs for the unit tests
       ghl_con2prim_diagnostics diagnostics;
       ghl_initialize_diagnostics(&diagnostics);
-      ghl_metric_quantities ADM_metric;
+      ghl_metric_quantities metric_adm;
       ghl_primitive_quantities prims;
       ghl_conservative_quantities cons, cons_undens;
 
@@ -197,10 +197,10 @@ int main(int argc, char **argv) {
             betax[i], betay[i], betaz[i],
             gxx[i], gxy[i], gxz[i],
             gyy[i], gyz[i], gzz[i],
-            &ADM_metric);
+            &metric_adm);
 
       ghl_ADM_aux_quantities metric_aux;
-      ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+      ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
       ghl_initialize_primitives(
             poison, poison, poison,
@@ -214,10 +214,10 @@ int main(int argc, char **argv) {
             S_x[i], S_y[i], S_z[i],
             ent_star[i], poison, &cons);
 
-      ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
-      ghl_guess_primitives(&eos, &ADM_metric, &cons, &prims);
+      ghl_undensitize_conservatives(metric_adm.sqrt_detgamma, &cons, &cons_undens);
+      ghl_guess_primitives(&eos, &metric_adm, &cons, &prims);
 
-      const int check = ghl_con2prim_hybrid_select_method(methods[method], &params, &eos, &ADM_metric, &metric_aux, &cons_undens, &prims, &diagnostics);
+      const int check = ghl_con2prim_hybrid_select_method(methods[method], &params, &eos, &metric_adm, &metric_aux, &cons_undens, &prims, &diagnostics);
       // This complicated mess is because failure mode 6 in Noble is very unpredictable. As such, whether it fails
       // or not can change by simply using a different compiler. The following bypasses errors associated with
       // different return values and doesn't skip the comparison of returned values for non-zero values.

--- a/Unit_Tests/unit_test_con2prim_tabulated.c
+++ b/Unit_Tests/unit_test_con2prim_tabulated.c
@@ -85,15 +85,15 @@ void generate_test_data(
       }
 
       // Set metric quantities to Minkowski
-      ghl_metric_quantities ADM_metric;
+      ghl_metric_quantities metric_adm;
       ghl_initialize_metric(1,
                         0, 0, 0,
                         1, 0, 0,
                         1, 0, 1,
-                        &ADM_metric);
+                        &metric_adm);
 
       ghl_ADM_aux_quantities metric_aux;
-      ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+      ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
       srand(0);
       for(int i=0;i<npoints;i++) {
@@ -144,7 +144,7 @@ void generate_test_data(
                                 Bx, By, Bz,
                                 xent, xye, xtemp,
                                 &prims_orig);
-          ghl_error_codes_t error = ghl_limit_v_and_compute_u0(params, &ADM_metric, &prims_orig, &diagnostics.speed_limited);
+          ghl_error_codes_t error = ghl_limit_v_and_compute_u0(params, &metric_adm, &prims_orig, &diagnostics.speed_limited);
           ghl_abort_if_error(error);
 
           // Set prim guesses
@@ -159,14 +159,14 @@ void generate_test_data(
           // Compute conserved variables and Tmunu
           ghl_conservative_quantities cons;
           __attribute__((unused)) ghl_stress_energy dummy;
-          ghl_compute_conservs_and_Tmunu(&ADM_metric, &metric_aux, &prims_orig, &cons, &dummy);
+          ghl_compute_conservs_and_Tmunu(&metric_adm, &metric_aux, &prims_orig, &cons, &dummy);
 
           // Undensitize the conserved variables
           ghl_conservative_quantities cons_undens;
-          ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
+          ghl_undensitize_conservatives(metric_adm.sqrt_detgamma, &cons, &cons_undens);
 
           // Now perform the con2prim
-          if( ghl_con2prim_tabulated_multi_method(params, eos, &ADM_metric, &metric_aux, &cons_undens, &prims, &diagnostics) )
+          if( ghl_con2prim_tabulated_multi_method(params, eos, &metric_adm, &metric_aux, &cons_undens, &prims, &diagnostics) )
             ghl_error("Con2Prim failed\n");
 
           prims.vU[0] = prims.vU[0]/prims.u0;
@@ -208,15 +208,15 @@ void run_unit_test(
       ghl_error("Problem reading input data files (%d != %d)\n", n1, n2);
 
     const int npoints = n1;
-    ghl_metric_quantities ADM_metric;
+    ghl_metric_quantities metric_adm;
     ghl_initialize_metric(1,
                       0, 0, 0,
                       1, 0, 0,
                       1, 0, 1,
-                      &ADM_metric);
+                      &metric_adm);
 
     ghl_ADM_aux_quantities metric_aux;
-    ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+    ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
     for(int i=0;i<npoints;i++) {
       for(int j=0;j<npoints;j++) {
@@ -232,14 +232,14 @@ void run_unit_test(
         // Compute conserved variables and Tmunu
         ghl_conservative_quantities cons;
         __attribute__((unused)) ghl_stress_energy dummy;
-        ghl_compute_conservs_and_Tmunu(&ADM_metric, &metric_aux, &prims, &cons, &dummy);
+        ghl_compute_conservs_and_Tmunu(&metric_adm, &metric_aux, &prims, &cons, &dummy);
 
         // Undensitize the conserved variables
         ghl_conservative_quantities cons_undens;
-        ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
+        ghl_undensitize_conservatives(metric_adm.sqrt_detgamma, &cons, &cons_undens);
 
         // Now perform the con2prim
-        if( ghl_con2prim_tabulated_multi_method(params, eos, &ADM_metric, &metric_aux, &cons_undens, &prims, &diagnostics) )
+        if( ghl_con2prim_tabulated_multi_method(params, eos, &metric_adm, &metric_aux, &cons_undens, &prims, &diagnostics) )
           ghl_error("Con2Prim failed\n");
 
         prims.vU[0] = prims.vU[0]/prims.u0;

--- a/Unit_Tests/unit_test_enforce_primitive_limits_and_compute_u0.c
+++ b/Unit_Tests/unit_test_enforce_primitive_limits_and_compute_u0.c
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
   for(int i=0;i<arraylength;i++) {
 
     // Define the various GRHayL structs for the unit tests
-    ghl_metric_quantities ADM_metric;
+    ghl_metric_quantities metric_adm;
     ghl_primitive_quantities prims;
 
     // Read initial data accompanying trusted output
@@ -165,10 +165,10 @@ int main(int argc, char **argv) {
                       betax[i], betay[i], betaz[i],
                       gxx[i], gxy[i], gxz[i],
                       gyy[i], gyz[i], gzz[i],
-                      &ADM_metric);
+                      &metric_adm);
 
     ghl_ADM_aux_quantities metric_aux;
-    ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+    ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
     ghl_initialize_primitives(
                       rho_b[i], press[i], eps[i],
@@ -179,7 +179,7 @@ int main(int argc, char **argv) {
 
     //This applies limits on the primitives
     bool speed_limited;
-    ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(&params, &eos, &ADM_metric, &prims, &speed_limited);
+    ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(&params, &eos, &metric_adm, &prims, &speed_limited);
     ghl_abort_if_error(error);
 
     ghl_primitive_quantities prims_trusted, prims_pert;
@@ -220,15 +220,15 @@ int main(int argc, char **argv) {
   double P_cold = 0.0;
   ghl_hybrid_compute_P_cold(&eos, rho_test, &P_cold);
 
-  ghl_metric_quantities ADM_metric;
+  ghl_metric_quantities metric_adm;
   ghl_initialize_metric(
         1.0, 0.0, 0.0, 0.0,
         1.0, 0.0, 0.0,
         1.0, 0.0, 1.0,
-        &ADM_metric);
+        &metric_adm);
 
   ghl_ADM_aux_quantities metric_aux;
-  ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+  ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
   ghl_primitive_quantities prims;
   ghl_initialize_primitives(
@@ -240,7 +240,7 @@ int main(int argc, char **argv) {
 
   params.psi6threshold = 0;
   bool speed_limited;
-  ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(&params, &eos, &ADM_metric, &prims, &speed_limited);
+  ghl_error_codes_t error = ghl_enforce_primitive_limits_and_compute_u0(&params, &eos, &metric_adm, &prims, &speed_limited);
   ghl_abort_if_error(error);
   if( relative_error(1e5*P_cold, prims.press) > 1e-20 )
     ghl_error("Pressure reset failure: returned value %e vs expected %e\n",
@@ -251,7 +251,7 @@ int main(int argc, char **argv) {
   prims.rho   = 12.0*eos.rho_atm;
   ghl_hybrid_compute_P_cold(&eos, prims.rho, &P_cold);
   prims.press = 1e3*P_cold;
-  error = ghl_enforce_primitive_limits_and_compute_u0(&params, &eos, &ADM_metric, &prims, &speed_limited);
+  error = ghl_enforce_primitive_limits_and_compute_u0(&params, &eos, &metric_adm, &prims, &speed_limited);
   ghl_abort_if_error(error);
   if( relative_error(1e2*P_cold, prims.press) > 1e-20 )
     ghl_error("Pressure reset failure: returned value %e vs expected %e\n",
@@ -267,13 +267,13 @@ int main(int argc, char **argv) {
       Gamma_th, &simple_eos);
   prims.rho = 0;
   prims.press = 0;
-  error = ghl_enforce_primitive_limits_and_compute_u0(&params, &simple_eos, &ADM_metric, &prims, &speed_limited);
+  error = ghl_enforce_primitive_limits_and_compute_u0(&params, &simple_eos, &metric_adm, &prims, &speed_limited);
   ghl_abort_if_error(error);
   if(fabs(prims.rho - rho_b_min) > 1e-50 || fabs(prims.press - press_min) > 1e-50)
     ghl_error("Minimum test failed for simple eos: %e %e\n", prims.rho, prims.press);
   prims.rho = 1e10;
   prims.press = 1e10;
-  error = ghl_enforce_primitive_limits_and_compute_u0(&params, &simple_eos, &ADM_metric, &prims, &speed_limited);
+  error = ghl_enforce_primitive_limits_and_compute_u0(&params, &simple_eos, &metric_adm, &prims, &speed_limited);
   ghl_abort_if_error(error);
   if(fabs(prims.rho - rho_max) > 1e-50 || fabs(prims.press - press_max) > 1e-50)
     ghl_error("Maximum test failed for simple eos: %e %e\n", prims.rho, prims.press);

--- a/Unit_Tests/unit_test_hybrid_failure.c
+++ b/Unit_Tests/unit_test_hybrid_failure.c
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
   for(int i=0; i<arraylength; i++) {
     ghl_con2prim_diagnostics diagnostics;
     ghl_initialize_diagnostics(&diagnostics);
-    ghl_metric_quantities ADM_metric;
+    ghl_metric_quantities metric_adm;
     ghl_primitive_quantities prims;
     ghl_conservative_quantities cons, cons_undens;
 
@@ -99,10 +99,10 @@ int main(int argc, char **argv) {
                       betax[i], betay[i], betaz[i],
                       gxx[i], gxy[i], gxz[i],
                       gyy[i], gyz[i], gzz[i],
-                      &ADM_metric);
+                      &metric_adm);
 
     ghl_ADM_aux_quantities metric_aux;
-    ghl_compute_ADM_auxiliaries(&ADM_metric, &metric_aux);
+    ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
 
     ghl_initialize_primitives(
                         poison, poison, poison,
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
 
     if (i==0) {
       params.calc_prim_guess = false;
-      prims.rho   = cons.rho/ADM_metric.sqrt_detgamma;
+      prims.rho   = cons.rho/metric_adm.sqrt_detgamma;
       prims.u0    = 1.0;
       prims.vU[0] = 2.0;
       prims.vU[1] = 2.0;
@@ -126,21 +126,21 @@ int main(int argc, char **argv) {
              S_x[i], S_y[i], S_z[i],
              poison, poison, &cons);
 
-    ghl_undensitize_conservatives(ADM_metric.sqrt_detgamma, &cons, &cons_undens);
-    int check = ghl_con2prim_hybrid_multi_method(&params, &eos, &ADM_metric, &metric_aux, &cons_undens, &prims, &diagnostics);
+    ghl_undensitize_conservatives(metric_adm.sqrt_detgamma, &cons, &cons_undens);
+    int check = ghl_con2prim_hybrid_multi_method(&params, &eos, &metric_adm, &metric_aux, &cons_undens, &prims, &diagnostics);
     if(check != expected_errors[i])
       ghl_error("Noble2D has returned a different failure code: old %d and new %d", i+1, check);
 
     if(i==0) {
       // This just gets coverage for the success branches
       params.main_routine = ghl_con2prim_id_Font1D;
-      int check = ghl_con2prim_hybrid_multi_method(&params, &eos, &ADM_metric, &metric_aux, &cons_undens, &prims, &diagnostics);
+      int check = ghl_con2prim_hybrid_multi_method(&params, &eos, &metric_adm, &metric_aux, &cons_undens, &prims, &diagnostics);
       if(check != 0)
         ghl_error("Font1D has returned a different failure code: old %d and new %d", 0, check);
       params.main_routine = ghl_con2prim_id_Noble2D;
       for (int j=0; j<3; j++) {
         params.backup_routine[2-j] = ghl_con2prim_id_Font1D;
-        int check = ghl_con2prim_hybrid_multi_method(&params, &eos, &ADM_metric, &metric_aux, &cons_undens, &prims, &diagnostics);
+        int check = ghl_con2prim_hybrid_multi_method(&params, &eos, &metric_adm, &metric_aux, &cons_undens, &prims, &diagnostics);
         if(check != 0)
           ghl_error("Font1D has returned a different failure code: old %d and new %d", 0, check);
         params.backup_routine[2-j] = ghl_con2prim_id_Noble2D;
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
     } else if (i==3) {
       // Here, we can check the Font Fix failure condition (there's just one return value)
       params.backup_routine[0] = ghl_con2prim_id_Font1D;
-      int check = ghl_con2prim_hybrid_multi_method(&params, &eos, &ADM_metric, &metric_aux, &cons_undens, &prims, &diagnostics);
+      int check = ghl_con2prim_hybrid_multi_method(&params, &eos, &metric_adm, &metric_aux, &cons_undens, &prims, &diagnostics);
       if(check != ghl_error_c2p_max_iter)
         ghl_error("Font1D has returned a different failure code: old %d and new %d", 1, check);
       params.backup_routine[0] = ghl_con2prim_id_None;


### PR DESCRIPTION
This PR renames local variables used by `GRHayL` from `ADM_metric` to `metric_adm`, making the notation more consistent with the already used `metric_aux` variable.