### PR TITLE
New tabulated EOS Con2prim Guess

### DIFF
--- a/GRHayL/Con2Prim/Hybrid/Noble/initialize_Noble.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/initialize_Noble.c
@@ -50,9 +50,7 @@ ghl_error_codes_t ghl_initialize_Noble(
   const double utU_guess[3] = {prims->u0*(prims->vU[0] + metric_adm->betaU[0]),
                                prims->u0*(prims->vU[1] + metric_adm->betaU[1]),
                                prims->u0*(prims->vU[2] + metric_adm->betaU[2])};
-  const double tmp_u = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, utU_guess);
-
-  double utsq = tmp_u;
+  double utsq = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, utU_guess);
 
   if( (utsq < 0.) && (fabs(utsq) < 1.0e-13) ) {
     utsq = fabs(utsq);
@@ -138,9 +136,7 @@ ghl_error_codes_t ghl_initialize_Noble_entropy(
   const double utU_guess[3] = {prims->u0*(prims->vU[0] + metric_adm->betaU[0]),
                                prims->u0*(prims->vU[1] + metric_adm->betaU[1]),
                                prims->u0*(prims->vU[2] + metric_adm->betaU[2])};
-  const double tmp_u = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, utU_guess);
-
-  double utsq = tmp_u;
+  double utsq = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, utU_guess);
 
   if( (utsq < 0.) && (fabs(utsq) < 1.0e-13) ) {
     utsq = fabs(utsq);

--- a/GRHayL/Con2Prim/Hybrid/Noble/initialize_Noble.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/initialize_Noble.c
@@ -50,11 +50,9 @@ ghl_error_codes_t ghl_initialize_Noble(
   const double utU_guess[3] = {prims->u0*(prims->vU[0] + metric_adm->betaU[0]),
                                prims->u0*(prims->vU[1] + metric_adm->betaU[1]),
                                prims->u0*(prims->vU[2] + metric_adm->betaU[2])};
-  double utsq = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, utU_guess);
+  const double utsq = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, utU_guess);
 
-  if( (utsq < 0.) && (fabs(utsq) < 1.0e-13) ) {
-    utsq = fabs(utsq);
-  } else if(utsq < 0.0 || utsq > 10.0) {
+  if(utsq < 0.0 || utsq > 10.0) {
     return ghl_error_invalid_utsq;
   }
 
@@ -136,11 +134,9 @@ ghl_error_codes_t ghl_initialize_Noble_entropy(
   const double utU_guess[3] = {prims->u0*(prims->vU[0] + metric_adm->betaU[0]),
                                prims->u0*(prims->vU[1] + metric_adm->betaU[1]),
                                prims->u0*(prims->vU[2] + metric_adm->betaU[2])};
-  double utsq = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, utU_guess);
+  const double utsq = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, utU_guess);
 
-  if( (utsq < 0.) && (fabs(utsq) < 1.0e-13) ) {
-    utsq = fabs(utsq);
-  } else if(utsq < 0.0 || utsq > 10.0) {
+  if(utsq < 0.0 || utsq > 10.0) {
     return ghl_error_invalid_utsq;
   }
 
@@ -151,9 +147,9 @@ ghl_error_codes_t ghl_initialize_Noble_entropy(
   //   i.e. you don't get positive values for dP/d(vsq).
   const double rho0 = harm_aux->D / W;
   const double Gamma_ppoly = eos->Gamma_ppoly[ghl_hybrid_find_polytropic_index(eos, rho0)];
-  const double Gm1        = Gamma_ppoly - 1.0;
+  const double Gm1 = Gamma_ppoly - 1.0;
 
-  const double rho_Gm1     = pow(rho0,Gm1);     // HARM auxiliary variable
+  const double rho_Gm1 = pow(rho0,Gm1);     // HARM auxiliary variable
 
   /* The definition of the entropy density, S, is
    *

--- a/GRHayL/Con2Prim/Hybrid/Noble/initialize_Noble.c
+++ b/GRHayL/Con2Prim/Hybrid/Noble/initialize_Noble.c
@@ -52,7 +52,7 @@ ghl_error_codes_t ghl_initialize_Noble(
                                prims->u0*(prims->vU[2] + metric_adm->betaU[2])};
   const double tmp_u = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, utU_guess);
 
-  double utsq = tmp_u/(1.0-tmp_u);
+  double utsq = tmp_u;
 
   if( (utsq < 0.) && (fabs(utsq) < 1.0e-13) ) {
     utsq = fabs(utsq);
@@ -140,7 +140,7 @@ ghl_error_codes_t ghl_initialize_Noble_entropy(
                                prims->u0*(prims->vU[2] + metric_adm->betaU[2])};
   const double tmp_u = ghl_compute_vec2_from_vec3D(metric_adm->gammaDD, utU_guess);
 
-  double utsq = tmp_u/(1.0-tmp_u);
+  double utsq = tmp_u;
 
   if( (utsq < 0.) && (fabs(utsq) < 1.0e-13) ) {
     utsq = fabs(utsq);

--- a/GRHayL/Con2Prim/con2prim_multi_method.c
+++ b/GRHayL/Con2Prim/con2prim_multi_method.c
@@ -93,8 +93,9 @@ ghl_error_codes_t ghl_con2prim_hybrid_multi_method(
       ghl_primitive_quantities *restrict prims,
       ghl_con2prim_diagnostics *restrict diagnostics) {
 
-  if(params->calc_prim_guess)
-    ghl_guess_primitives(eos, metric_adm, cons_undens, prims);
+  if(params->calc_prim_guess) {
+    ghl_guess_primitives(params, eos, metric_adm, cons_undens, prims);
+  }
 
   // Store primitive guesses (used if con2prim fails)
   const ghl_primitive_quantities prims_guess = *prims;
@@ -148,8 +149,9 @@ ghl_error_codes_t ghl_con2prim_tabulated_multi_method(
 #ifdef GHL_DISABLE_HDF5
   return ghl_error_used_disabled_hdf5;
 #else
-  if(params->calc_prim_guess)
-    ghl_guess_primitives(eos, metric_adm, cons_undens, prims);
+  if(params->calc_prim_guess) {
+    ghl_guess_primitives(params, eos, metric_adm, cons_undens, prims);
+  }
 
   // Store primitive guesses (used if con2prim fails)
   const ghl_primitive_quantities prims_guess = *prims;

--- a/GRHayL/Con2Prim/guess_primitives.c
+++ b/GRHayL/Con2Prim/guess_primitives.c
@@ -44,11 +44,11 @@ static void ghl_guess_primitives_hybrid_simple(
   (void)params;
 
   // Use atmosphere as initial guess:
-  prims->rho         = cons_undens->rho;
-  prims->u0          = 1.0;
-  prims->vU[0]       = -metric_adm->betaU[0];
-  prims->vU[1]       = -metric_adm->betaU[1];
-  prims->vU[2]       = -metric_adm->betaU[2];
+  prims->rho   = cons_undens->rho;
+  prims->u0    = 1.0;
+  prims->vU[0] = -metric_adm->betaU[0];
+  prims->vU[1] = -metric_adm->betaU[1];
+  prims->vU[2] = -metric_adm->betaU[2];
 
   // Compute remaining primitives
   ghl_hybrid_compute_P_cold_and_eps_cold(eos, prims->rho, &prims->press, &prims->eps);
@@ -83,9 +83,10 @@ static void ghl_guess_primitives_tabulated(
   Wminus2 = ghl_clamp(Wminus2, params->inv_sq_max_Lorentz_factor, 1.0);
   const double W = pow(Wminus2, -0.5);
 
-  // Compute rho and Y_e
+  // Compute rho Y_e, and u^0
   prims->rho = cons_undens->rho / W;
   prims->Y_e = cons_undens->Y_e / cons_undens->rho;
+  prims->u0  = W * metric_adm->lapseinv;
 
   // Compute eps, Eq. (43-44) of 1712.07538
   prims->eps = - 1.0 + (1.0 - W * W) * x / W

--- a/GRHayL/Con2Prim/guess_primitives.c
+++ b/GRHayL/Con2Prim/guess_primitives.c
@@ -5,8 +5,8 @@
  * @brief Computes an initial guess for the @ref Con2Prim solvers
  *
  * @details
- * This function sets a default initial guess for when a better guess is not
- * available. It sets
+ * This function sets a default initial guess for hybrid or simple EOSs. It can
+ * be used whenever a better guess is not available. It sets
  *
  * \f[
  * \begin{aligned}
@@ -33,11 +33,15 @@
  *
  * @param[out] prims pointer to ghl_primitive_quantities containing the initial guess
  */
-void ghl_guess_primitives(
+static void ghl_guess_primitives_hybrid_simple(
+      const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
       const ghl_metric_quantities *restrict metric_adm,
       const ghl_conservative_quantities *restrict cons_undens,
       ghl_primitive_quantities *restrict prims) {
+
+  // params is not used by this function
+  (void)params;
 
   // Use atmosphere as initial guess:
   prims->rho         = cons_undens->rho;
@@ -48,7 +52,80 @@ void ghl_guess_primitives(
   prims->Y_e         = cons_undens->Y_e/cons_undens->rho;
   prims->temperature = eos->T_max;
 
-  // If using hybrid or ideal fluid EOS, compute P_cold and eps_cold
-  if( eos->eos_type == ghl_eos_hybrid || eos->eos_type == ghl_eos_simple )
-    ghl_hybrid_compute_P_cold_and_eps_cold(eos, prims->rho, &prims->press, &prims->eps);
+  // Compute remaining primitives
+  ghl_hybrid_compute_P_cold_and_eps_cold(eos, prims->rho, &prims->press, &prims->eps);
+}
+
+static void ghl_guess_primitives_tabulated(
+      const ghl_parameters *restrict params,
+      const ghl_eos_parameters *restrict eos,
+      const ghl_metric_quantities *restrict metric_adm,
+      const ghl_conservative_quantities *restrict cons_undens,
+      ghl_primitive_quantities *restrict prims) {
+
+  // Compute auxiliary variables
+  double SU[3], B_squared, S_squared, BdotS;
+  ghl_compute_SU_Bsq_Ssq_BdotS(metric_adm, cons_undens, prims,
+                               SU, &B_squared, &S_squared, &BdotS);
+
+  // Compute Palenzuela variables {q, r, s, t}
+  const double invD = 1.0 / cons_undens->rho;
+  const double q = cons_undens->tau * invD;
+  const double r = S_squared * invD * invD;
+  const double s = B_squared * invD;
+  const double t = BdotS / pow(cons_undens->rho, 1.5);
+
+  // Compute the lower bound of the x variable, Eq. (35) of 1712.07538
+  const double x = 1.0 + q - s;
+
+  // Compute W, Eq. (42) of 1712.07538
+  const double tmp_numer = x * x * r + (2.0 * x + s) * t * t;
+  const double tmp_denom = x * x * (x + s) * (x + s);
+  double Wminus2 = 1.0 - tmp_numer / tmp_denom;
+  Wminus2 = ghl_clamp(Wminus2, params->inv_sq_max_Lorentz_factor, 1.0);
+  const double W = pow(Wminus2, -0.5);
+
+  // Compute rho and Y_e
+  prims->rho = cons_undens->rho / W;
+  prims->Y_e = cons_undens->Y_e / cons_undens->rho;
+
+  // Compute eps, Eq. (43-44) of 1712.07538
+  prims->eps = - 1.0 + (1.0 - W * W) * x / W
+             + W * (1.0 + q - s + t * t / (2.0 * x * x) + s / (2.0 * W * W));
+
+  // Enforce table bounds, then compute missing hydrodynamic quantities
+  ghl_tabulated_enforce_bounds_rho_Ye_eps(eos, &prims->rho, &prims->Y_e, &prims->eps);
+  ghl_tabulated_compute_P_S_T_from_eps(eos, prims->rho, prims->Y_e, prims->eps,
+                                       &prims->press, &prims->entropy, &prims->temperature);
+
+  // Compute the velocities. We start by computing the Valencia velocity v_n^i
+  // using Eq. (24) of 1712.07538, with z = x rho W. We use it to compute
+  // \tilde{u}^i = W * v_n^i, following the discussion below Eq. (15) of
+  // astro-ph/0512420. Finally, we use a GRHayL function to limit the velocity
+  // and compute the appropriate primitive variable v^i = u^i / u^0.
+  const double z = x * prims->rho * W;
+  double utildeU[3] = {
+    W * (SU[0] + BdotS * prims->BU[0] / z) / (z + B_squared),
+    W * (SU[1] + BdotS * prims->BU[1] / z) / (z + B_squared),
+    W * (SU[2] + BdotS * prims->BU[2] / z) / (z + B_squared),
+  };
+  ghl_limit_utilde_and_compute_v(params, metric_adm, utildeU, prims);
+}
+
+void ghl_guess_primitives(
+      const ghl_parameters *restrict params,
+      const ghl_eos_parameters *restrict eos,
+      const ghl_metric_quantities *restrict metric_adm,
+      const ghl_conservative_quantities *restrict cons_undens,
+      ghl_primitive_quantities *restrict prims) {
+
+  switch(eos->eos_type) {
+    case ghl_eos_hybrid:
+    case ghl_eos_simple:
+      ghl_guess_primitives_hybrid_simple(params, eos, metric_adm, cons_undens, prims);
+      break;
+    case ghl_eos_tabulated:
+      ghl_guess_primitives_tabulated(params, eos, metric_adm, cons_undens, prims);
+      break;
+  }
 }

--- a/GRHayL/Con2Prim/guess_primitives.c
+++ b/GRHayL/Con2Prim/guess_primitives.c
@@ -49,8 +49,6 @@ static void ghl_guess_primitives_hybrid_simple(
   prims->vU[0]       = -metric_adm->betaU[0];
   prims->vU[1]       = -metric_adm->betaU[1];
   prims->vU[2]       = -metric_adm->betaU[2];
-  prims->Y_e         = cons_undens->Y_e/cons_undens->rho;
-  prims->temperature = eos->T_max;
 
   // Compute remaining primitives
   ghl_hybrid_compute_P_cold_and_eps_cold(eos, prims->rho, &prims->press, &prims->eps);
@@ -93,7 +91,9 @@ static void ghl_guess_primitives_tabulated(
   prims->eps = - 1.0 + (1.0 - W * W) * x / W
              + W * (1.0 + q - s + t * t / (2.0 * x * x) + s / (2.0 * W * W));
 
-  // Enforce table bounds, then compute missing hydrodynamic quantities
+  // Enforce table bounds, then compute missing hydrodynamic quantities, using
+  // T = T_max as an initial guess.
+  prims->temperature = eos->T_max;
   ghl_tabulated_enforce_bounds_rho_Ye_eps(eos, &prims->rho, &prims->Y_e, &prims->eps);
   ghl_tabulated_compute_P_S_T_from_eps(eos, prims->rho, prims->Y_e, prims->eps,
                                        &prims->press, &prims->entropy, &prims->temperature);

--- a/GRHayL/Con2Prim/guess_primitives.c
+++ b/GRHayL/Con2Prim/guess_primitives.c
@@ -19,10 +19,10 @@
  * \f]
  *
  * This choice sets the transport/utilde velocity \f$ v^i+\beta^i \f$ to zero;
- * it is only an initial guess for the Con2Prim solve. Also, the quantity
- * \f$ T_\mathrm{max} \f$ uses ghl_eos_parameters::T_max. Finally, for hybrid or simple EOS,
- * we set the pressure and specific internal energy \f$ \epsilon \f$ to the
- * cold values.
+ * it is only an initial guess for the Con2Prim solve. We set the pressure and
+ * specific internal energy \f$ \epsilon \f$ to the cold values.
+ *
+ * @param[in] params pointer to ghl_parameters struct
  *
  * @param[in] eos pointer to ghl_eos_parameters struct
  *
@@ -54,6 +54,30 @@ static void ghl_guess_primitives_hybrid_simple(
   ghl_hybrid_compute_P_cold_and_eps_cold(eos, prims->rho, &prims->press, &prims->eps);
 }
 
+/**
+ * @ingroup Con2Prim
+ * @brief Computes an initial guess for the @ref Con2Prim solvers
+ *
+ * @details
+ * This function sets a default initial guess for tabulated EOSs. It can be
+ * used whenever a better guess is not available. It sets primitives following
+ * the primitive-recovery strategy of the Palenzuela et al. routine, as outlined
+ * in Siegel et al. (2018; https://arxiv.org/pdf/1712.07538).
+ *
+ * The only required guess is the temperature. We use \f$ T = T_\mathrm{max} \f$,
+ * which uses ghl_eos_parameters::T_max.
+ *
+ * @param[in] params pointer to ghl_parameters struct
+ *
+ * @param[in] eos pointer to ghl_eos_parameters struct
+ *
+ * @param[in] metric_adm pointer to ghl_metric_quantities struct with ADM metric
+ *
+ * @param[in] cons_undens pointer to ghl_conservative_quantities struct with
+ *                        **undensitized** conservative variables
+ *
+ * @param[out] prims pointer to ghl_primitive_quantities containing the initial guess
+ */
 static void ghl_guess_primitives_tabulated(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
@@ -113,6 +137,21 @@ static void ghl_guess_primitives_tabulated(
   ghl_limit_utilde_and_compute_v(params, metric_adm, utildeU, prims);
 }
 
+/**
+ * @ingroup Con2Prim
+ * @brief Computes an initial guess for the @ref Con2Prim solvers
+ *
+ * @param[in] params pointer to ghl_parameters struct
+ *
+ * @param[in] eos pointer to ghl_eos_parameters struct
+ *
+ * @param[in] metric_adm pointer to ghl_metric_quantities struct with ADM metric
+ *
+ * @param[in] cons_undens pointer to ghl_conservative_quantities struct with
+ *                        **undensitized** conservative variables
+ *
+ * @param[out] prims pointer to ghl_primitive_quantities containing the initial guess
+ */
 void ghl_guess_primitives(
       const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,

--- a/GRHayL/EOS/Tabulated/NRPyEOS_initialize_tabulated_functions.c
+++ b/GRHayL/EOS/Tabulated/NRPyEOS_initialize_tabulated_functions.c
@@ -19,6 +19,7 @@ void NRPyEOS_initialize_tabulated_functions() {
   ghl_tabulated_compute_muhat_mue_mup_mun_Xn_Xp_from_T = &NRPyEOS_muhat_mue_mup_mun_Xn_and_Xp_from_rho_Ye_T;
   ghl_tabulated_compute_T_from_eps                     = &NRPyEOS_T_from_rho_Ye_eps;
   ghl_tabulated_compute_P_T_from_eps                   = &NRPyEOS_P_and_T_from_rho_Ye_eps;
+  ghl_tabulated_compute_P_S_T_from_eps                 = &NRPyEOS_P_S_and_T_from_rho_Ye_eps;
   ghl_tabulated_compute_P_T_from_S                     = &NRPyEOS_P_and_T_from_rho_Ye_S;
   ghl_tabulated_compute_P_eps_S_T_from_h               = &NRPyEOS_P_eps_S_and_T_from_rho_Ye_h;
   ghl_tabulated_compute_P_eps_dPdrho_dPdeps_T_from_h   = &NRPyEOS_P_eps_dPdrho_dPdeps_and_T_from_rho_Ye_h;

--- a/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_S_and_T_from_rho_Ye_eps.c
+++ b/GRHayL/EOS/Tabulated/interpolators/NRPyEOS_P_S_and_T_from_rho_Ye_eps.c
@@ -1,0 +1,34 @@
+#include "ghl_nrpyeos_tabulated.h"
+/*
+ * (c) 2022 Leo Werneck
+ */
+ghl_error_codes_t NRPyEOS_P_S_and_T_from_rho_Ye_eps(
+      const ghl_eos_parameters *restrict eos,
+      const double rho,
+      const double Y_e,
+      const double eps,
+      double *restrict P,
+      double *restrict S,
+      double *restrict T) {
+
+  // Step 1: Set EOS table keys
+  const int keys[2] = {NRPyEOS_press_key, NRPyEOS_entropy_key};
+
+  // Step 2: Declare output array
+  double outvars[2];
+
+  // Step 3: Perform the interpolation
+  const double root_finding_precision = eos->root_finding_precision;
+  const ghl_error_codes_t error = NRPyEOS_from_rho_Ye_aux_find_T_and_interpolate_n_quantities(eos, 2, root_finding_precision,
+                                                                                rho, Y_e, eps, NRPyEOS_eps_key,
+                                                                                keys, outvars, T);
+
+  // Step 4: Check for errors
+  if(error)
+    return error;
+
+  // Step 5: Update output variables
+  *P = outvars[0];
+  *S = outvars[1];
+  return ghl_success;
+}

--- a/GRHayL/EOS/Tabulated/interpolators/make.code.defn
+++ b/GRHayL/EOS/Tabulated/interpolators/make.code.defn
@@ -9,6 +9,7 @@ SRCS = NRPyEOS_eps_from_rho_Ye_T.c                                   \
        NRPyEOS_P_and_eps_from_rho_Ye_T.c                             \
        NRPyEOS_T_from_rho_Ye_eps.c                                   \
        NRPyEOS_P_and_T_from_rho_Ye_eps.c                             \
+       NRPyEOS_P_S_and_T_from_rho_Ye_eps.c                           \
        NRPyEOS_P_cs2_and_T_from_rho_Ye_eps.c                         \
        NRPyEOS_eps_cs2_and_T_from_rho_Ye_P.c                         \
        NRPyEOS_P_and_T_from_rho_Ye_S.c                               \

--- a/GRHayL/include/ghl_con2prim.h
+++ b/GRHayL/include/ghl_con2prim.h
@@ -58,6 +58,7 @@ void ghl_undensitize_conservatives(
       ghl_conservative_quantities *restrict cons_undens);
 
 void ghl_guess_primitives(
+      const ghl_parameters *restrict params,
       const ghl_eos_parameters *restrict eos,
       const ghl_metric_quantities *restrict metric_adm,
       const ghl_conservative_quantities *restrict cons,

--- a/GRHayL/include/ghl_eos_functions.h
+++ b/GRHayL/include/ghl_eos_functions.h
@@ -170,6 +170,15 @@ extern ghl_error_codes_t (*ghl_tabulated_compute_P_T_from_eps)(
       double *restrict P,
       double *restrict T);
 
+extern ghl_error_codes_t (*ghl_tabulated_compute_P_S_T_from_eps)(
+      const ghl_eos_parameters *restrict eos,
+      const double rho,
+      const double Y_e,
+      const double eps,
+      double *restrict P,
+      double *restrict S,
+      double *restrict T);
+
 extern ghl_error_codes_t (*ghl_tabulated_compute_P_cs2_T_from_eps)(
       const ghl_eos_parameters *restrict eos,
       const double rho,

--- a/GRHayL/include/ghl_eos_functions_declaration.h
+++ b/GRHayL/include/ghl_eos_functions_declaration.h
@@ -169,6 +169,15 @@ ghl_error_codes_t (*ghl_tabulated_compute_P_T_from_eps)(
       double *restrict P,
       double *restrict T);
 
+ghl_error_codes_t (*ghl_tabulated_compute_P_S_T_from_eps)(
+      const ghl_eos_parameters *restrict eos,
+      const double rho,
+      const double Y_e,
+      const double eps,
+      double *restrict P,
+      double *restrict S,
+      double *restrict T);
+
 ghl_error_codes_t (*ghl_tabulated_compute_P_cs2_T_from_eps)(
       const ghl_eos_parameters *restrict eos,
       const double rho,

--- a/GRHayL/include/ghl_nrpyeos_tabulated.h
+++ b/GRHayL/include/ghl_nrpyeos_tabulated.h
@@ -169,6 +169,15 @@ ghl_error_codes_t NRPyEOS_P_and_T_from_rho_Ye_eps(
       double *restrict P,
       double *restrict T);
 
+ghl_error_codes_t NRPyEOS_P_S_and_T_from_rho_Ye_eps(
+      const ghl_eos_parameters *restrict eos_params,
+      const double rho,
+      const double Y_e,
+      const double eps,
+      double *restrict P,
+      double *restrict S,
+      double *restrict T);
+
 ghl_error_codes_t NRPyEOS_P_cs2_and_T_from_rho_Ye_eps(
       const ghl_eos_parameters *restrict eos_params,
       const double rho,

--- a/Unit_Tests/data_gen/unit_test_data_con2prim_multi_method_hybrid.c
+++ b/Unit_Tests/data_gen/unit_test_data_con2prim_multi_method_hybrid.c
@@ -511,8 +511,9 @@ int main(int argc, char **argv) {
               ent_star[i], poison, &cons);
 
         ghl_undensitize_conservatives(metric_adm.sqrt_detgamma, &cons, &cons_undens);
-        if(params.calc_prim_guess)
-          ghl_guess_primitives(&eos, &metric_adm, &cons, &prims);
+        if(params.calc_prim_guess) {
+          ghl_guess_primitives(&params, &eos, &metric_adm, &cons, &prims);
+        }
         c2p_check[i] = ghl_con2prim_hybrid_select_method(
               methods[routine], &params, &eos, &metric_adm, &metric_aux,
               &cons_undens, &prims, &diagnostics);

--- a/Unit_Tests/unit_test_con2prim_multi_method_hybrid.c
+++ b/Unit_Tests/unit_test_con2prim_multi_method_hybrid.c
@@ -215,7 +215,7 @@ int main(int argc, char **argv) {
             ent_star[i], poison, &cons);
 
       ghl_undensitize_conservatives(metric_adm.sqrt_detgamma, &cons, &cons_undens);
-      ghl_guess_primitives(&eos, &metric_adm, &cons, &prims);
+      ghl_guess_primitives(&params, &eos, &metric_adm, &cons, &prims);
 
       const int check = ghl_con2prim_hybrid_select_method(methods[method], &params, &eos, &metric_adm, &metric_aux, &cons_undens, &prims, &diagnostics);
       // This complicated mess is because failure mode 6 in Noble is very unpredictable. As such, whether it fails

--- a/Unit_Tests/unit_test_con2prim_tabulated.c
+++ b/Unit_Tests/unit_test_con2prim_tabulated.c
@@ -44,11 +44,11 @@ void generate_test_data(
           test_Y_e         *= (1+randf(-1,1)*1e-14);
           test_rho         *= (1+randf(-1,1)*1e-14);
           test_T           *= (1+randf(-1,1)*1e-14);
-          test_logWm1_min  *= (1+randf(-1,1)*1e-14);
-          test_logWm1_max  *= (1+randf(-1,1)*1e-14);
+          test_logWm1_min  *= (1+randf( 0,1)*1e-14);
+          test_logWm1_max  *= (1+randf(-1,0)*1e-14);
           dlogWm1          *= (1+randf(-1,1)*1e-14);
-          test_logPmoP_min *= (1+randf(-1,1)*1e-14);
-          test_logPmoP_max *= (1+randf(-1,1)*1e-14);
+          test_logPmoP_min *= (1+randf( 0,1)*1e-14);
+          test_logPmoP_max *= (1+randf(-1,0)*1e-14);
           dlogPmoP         *= (1+randf(-1,1)*1e-14);
         }
       }
@@ -69,28 +69,27 @@ void generate_test_data(
         dlt          = (ltmax - ltmin)/(npoints-1);
         if( perturb ) {
           test_Y_e     *= (1+randf(-1,1)*1e-14);
-          test_rho_min *= (1+randf(-1,1)*1e-14);
-          test_rho_max *= (1+randf(-1,1)*1e-14);
-          test_T_min   *= (1+randf(-1,1)*1e-14);
-          test_T_max   *= (1+randf(-1,1)*1e-14);
+          test_rho_min *= (1+randf( 0,1)*1e-14);
+          test_rho_max *= (1+randf(-1,0)*1e-14);
+          test_T_min   *= (1+randf( 0,1)*1e-14);
+          test_T_max   *= (1+randf(-1,0)*1e-14);
           test_W       *= (1+randf(-1,1)*1e-14);
           test_logPmoP *= (1+randf(-1,1)*1e-14);
-          lrmin        *= (1+randf(-1,1)*1e-14);
-          lrmax        *= (1+randf(-1,1)*1e-14);
+          lrmin        *= (1+randf( 0,1)*1e-14);
+          lrmax        *= (1+randf(-1,0)*1e-14);
           dlr          *= (1+randf(-1,1)*1e-14);
-          ltmin        *= (1+randf(-1,1)*1e-14);
-          ltmax        *= (1+randf(-1,1)*1e-14);
+          ltmin        *= (1+randf( 0,1)*1e-14);
+          ltmax        *= (1+randf(-1,0)*1e-14);
           dlt          *= (1+randf(-1,1)*1e-14);
         }
       }
 
       // Set metric quantities to Minkowski
       ghl_metric_quantities metric_adm;
-      ghl_initialize_metric(1,
-                        0, 0, 0,
-                        1, 0, 0,
-                        1, 0, 1,
-                        &metric_adm);
+      ghl_initialize_metric(1, 0, 0, 0,
+                            1, 0, 0,
+                            1, 0, 1,
+                            &metric_adm);
 
       ghl_ADM_aux_quantities metric_aux;
       ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
@@ -123,7 +122,7 @@ void generate_test_data(
           double xprs  = 0.0;
           double xeps  = 0.0;
           double xent  = 0.0;
-          ghl_tabulated_compute_P_eps_S_from_T( eos, xrho, xye, xtemp, &xprs, &xeps, &xent );
+          ghl_tabulated_compute_P_eps_S_from_T(eos, xrho, xye, xtemp, &xprs, &xeps, &xent);
 
           const double v     = sqrt(1.0-1.0/(xW*xW));
           const double vx    = v*((double)rand())/((double)RAND_MAX);
@@ -140,10 +139,10 @@ void generate_test_data(
           // Set primitive quantities
           ghl_primitive_quantities prims_orig;
           ghl_initialize_primitives(xrho, xprs, xeps,
-                                vx, vy, vz,
-                                Bx, By, Bz,
-                                xent, xye, xtemp,
-                                &prims_orig);
+                                    vx, vy, vz,
+                                    Bx, By, Bz,
+                                    xent, xye, xtemp,
+                                    &prims_orig);
           ghl_error_codes_t error = ghl_limit_v_and_compute_u0(params, &metric_adm, &prims_orig, &diagnostics.speed_limited);
           ghl_abort_if_error(error);
 
@@ -205,11 +204,10 @@ void run_unit_test(
 
     const int npoints = n1;
     ghl_metric_quantities metric_adm;
-    ghl_initialize_metric(1,
-                      0, 0, 0,
-                      1, 0, 0,
-                      1, 0, 1,
-                      &metric_adm);
+    ghl_initialize_metric(1, 0, 0, 0,
+                          1, 0, 0,
+                          1, 0, 1,
+                          &metric_adm);
 
     ghl_ADM_aux_quantities metric_aux;
     ghl_compute_ADM_auxiliaries(&metric_adm, &metric_aux);
@@ -241,7 +239,8 @@ void run_unit_test(
                                                                     &metric_adm, &metric_aux,
                                                                     &cons_undens, &prims, &diagnostics);
         if(err != ghl_success) {
-          ghl_error("Con2Prim failed for routine %s\n", routine);
+          ghl_warn("Con2Prim failed for routine %s\n", routine);
+          ghl_abort_if_error(err);
         }
         if(diagnostics.which_routine == params->main_routine) {
           main_routine_successes++;
@@ -261,9 +260,9 @@ void run_unit_test(
 
 #define CHECK_WITH_TOLS(q_)                                              \
   if(ghl_pert_test_fail_with_tolerance(prims_trusted.q_,                 \
-                                             prims.q_,                   \
-                                             prims_pert.q_,              \
-                                             rtol, atol)) {              \
+                                       prims.q_,                         \
+                                       prims_pert.q_,                    \
+                                       rtol, atol)) {                    \
     ghl_info("%s exceeds error tolerance: %.15e %.15e %.15e -> %e %e\n", \
              #q_, prims_trusted.q_, prims_pert.q_, prims.q_,             \
              fabs(prims_trusted.q_ - prims.q_),                          \
@@ -277,6 +276,10 @@ void run_unit_test(
         CHECK_WITH_TOLS(rho);
         CHECK_WITH_TOLS(Y_e);
         CHECK_WITH_TOLS(press);
+
+        // Velocity tolerances need to be adjusted
+        atol = 4e-6;
+        rtol = 2e-6;
         CHECK_WITH_TOLS(vU[0]);
         CHECK_WITH_TOLS(vU[1]);
         CHECK_WITH_TOLS(vU[2]);
@@ -288,7 +291,8 @@ void run_unit_test(
         CHECK_WITH_TOLS(temperature);
         CHECK_WITH_TOLS(eps);
         if(failed) {
-          ghl_error("%s Con2Prim test failed\n", routine);
+          ghl_error("%s Con2Prim test failed: %e %e %e\n", routine,
+                    prims_trusted.rho, prims_trusted.Y_e, prims_trusted.temperature);
         }
       }
     }


### PR DESCRIPTION
This PR introduces a new initial guess for tabulated equation of state (EOS) routines. Essentially, we use the approach from the Palenzuela et al. routine to set an initial guess for the primitives by using the lower-bound of Eq. (35) of [Siegel et al. (2018)](https://arxiv.org/pdf/1712.07538).

This PR also fixes bugs in the `ghl_initialize_Noble` and `ghl_initialize_Noble_entropy` where the $\tilde{u}^2$ variable was being incorrectly set.